### PR TITLE
fix: Remove dompurify not working with gatsby

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "url": "https://github.com/comicrelief/component-library.git"
   },
   "dependencies": {
-    "dompurify": "^1.0.11",
     "@babel/cli": "^7.4.4",
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",

--- a/src/components/Atoms/RichText/RichText.js
+++ b/src/components/Atoms/RichText/RichText.js
@@ -2,19 +2,15 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-import DOMPurify from 'dompurify';
-
 export const Inner = styled.div`
   text-align: ${props => props.align};
 `;
 
 const RichText = ({ align, markup, ...rest }) => {
-  const sanitisedMarkup = DOMPurify.sanitize(markup);
-
   return (
     <Inner
       align={align}
-      dangerouslySetInnerHTML={{ __html: sanitisedMarkup }}
+      dangerouslySetInnerHTML={{ __html: markup }}
       {...rest}
     />
   );

--- a/src/components/Atoms/RichText/RichText.test.js
+++ b/src/components/Atoms/RichText/RichText.test.js
@@ -3,8 +3,7 @@ import 'jest-styled-components';
 import renderWithTheme from '../../../hoc/shallowWithTheme';
 import RichText from './RichText';
 
-const unsanitisedHTML =
-  "<p>Here's some copy</p><script>alert('bad things')</script><span>More copy</span>";
+const unsanitisedHTML = "<p>Here's some copy</p><span>More copy</span>";
 
 it('It sanitises markup and renders properly', () => {
   const tree = renderWithTheme(

--- a/src/components/Atoms/RichText/RichText.test.js
+++ b/src/components/Atoms/RichText/RichText.test.js
@@ -3,11 +3,11 @@ import 'jest-styled-components';
 import renderWithTheme from '../../../hoc/shallowWithTheme';
 import RichText from './RichText';
 
-const unsanitisedHTML = "<p>Here's some copy</p><span>More copy</span>";
+const htmlContent = "<p>Here's some copy</p><span>More copy</span>";
 
 it('It sanitises markup and renders properly', () => {
   const tree = renderWithTheme(
-    <RichText align="right" markup={unsanitisedHTML} />
+    <RichText align="right" markup={htmlContent} />
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`

--- a/yarn.lock
+++ b/yarn.lock
@@ -4279,11 +4279,6 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-dompurify@^1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-1.0.11.tgz#fe0f4a40d147f7cebbe31a50a1357539cfc1eb4d"
-  integrity sha512-XywCTXZtc/qCX3iprD1pIklRVk/uhl8BKpkTxr+ZyMVUzSUg7wkQXRBp/euJ5J5moa1QvfpvaPQVP71z1O59dQ==
-
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"


### PR DESCRIPTION
Type: fix

## Changes proposed in this PR

Dompurify will not work with gatsby built app. We will have to sanitise the content at the app level.
