### PR TITLE
feat: add zindex helper

### DIFF
--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,5 +1,13 @@
 _Hide Visually_
 
-`import hideVisually from '../../../theme/shared/hideVisually';`
+`import { hideVisually } from '@comicrelief/component-library';`
 
+how to use in your styled component
 `export const Component = styled.span'${hideVisually};';`
+
+_Z Index_
+
+`import { zIndex } from '@comicrelief/component-library';`
+
+how to use in your styled component
+`export const Component = styled.span'${zIndex('high')};';`

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,10 @@
 export { default as crTheme } from './theme/crTheme/theme';
 export { default as srTheme } from './theme/srTheme/theme';
 export { default as ThemeProvider } from './theme/ThemeProvider';
+
+/* Utils */
 export { default as hideVisually } from './theme/shared/hideVisually';
+export { default as zIndex } from './theme/shared/zIndex';
 
 /* Atoms */
 

--- a/src/theme/shared/zIndex.js
+++ b/src/theme/shared/zIndex.js
@@ -1,0 +1,22 @@
+import { css } from 'styled-components';
+
+const indexes = {
+  base: 0,
+  low: 1,
+  medium: 2,
+  high: 3
+};
+
+const zIndex = index => {
+  let value = indexes.base;
+
+  if (index) {
+    value = indexes[index];
+  }
+
+  return css`
+    z-index: ${value};
+  `;
+};
+
+export default zIndex;


### PR DESCRIPTION
Type: feature

## Changes proposed in this PR

To avoid using random `z-index` and possible positioning conflicts.

_Z Index_

`import { zIndex } from '@comicrelief/component-library';`

how to use in your styled component
```
const Component = styled.span'
    ${zIndex('high')};
';
```
