### PR TITLE
fix: #79 - window not defined

### DIFF
--- a/src/components/Molecules/Header/Nav/Nav.js
+++ b/src/components/Molecules/Header/Nav/Nav.js
@@ -84,7 +84,7 @@ const MainNav = ({ navItems }) => {
               index={index}
               isSubMenuOpen={!!isSubMenuOpen[group.id]}
             >
-              {!mobile ? (
+              {!isMobile ? (
                 <NavLink
                   href={group.url}
                   inline

--- a/src/components/Molecules/Header/Nav/Nav.js
+++ b/src/components/Molecules/Header/Nav/Nav.js
@@ -22,7 +22,7 @@ const MainNav = ({ navItems }) => {
   const [isSubMenuOpen, setIsSubMenuOpen] = useState({});
   const [isKeyPressed, setIsKeyPressed] = useState({});
   let [width] = useState(null);
-  let [mobile] = useState(null);
+  let mobile;
 
   useEffect(() => {
     // Detect window screen size

--- a/src/components/Molecules/Header/Nav/Nav.js
+++ b/src/components/Molecules/Header/Nav/Nav.js
@@ -22,7 +22,7 @@ const MainNav = ({ navItems }) => {
   const [isSubMenuOpen, setIsSubMenuOpen] = useState({});
   const [isKeyPressed, setIsKeyPressed] = useState({});
   let [width] = useState(null);
-  let mobile;
+  let mobile = useState(false);
 
   useEffect(() => {
     // Detect window screen size

--- a/src/components/Molecules/Header/Nav/Nav.js
+++ b/src/components/Molecules/Header/Nav/Nav.js
@@ -21,13 +21,14 @@ const MainNav = ({ navItems }) => {
   const [isExpandable, setIsExpandable] = useState(false);
   const [isSubMenuOpen, setIsSubMenuOpen] = useState({});
   const [isKeyPressed, setIsKeyPressed] = useState({});
-  let [width] = useState(null);
-  let mobile = useState(false);
+
+  const [isMobile, setIsMobile] = useState(false);
+
+  const width = typeof window !== 'undefined' ? window.innerWidth : null;
 
   useEffect(() => {
     // Detect window screen size
-    width = window.innerWidth;
-    mobile = width < sizes.medium;
+    setIsMobile(width < sizes.medium);
   }, []);
 
   const toggleBurgerMenu = event => {
@@ -36,7 +37,7 @@ const MainNav = ({ navItems }) => {
   };
 
   const toggleSubMenu = item => event => {
-    if (mobile) {
+    if (isMobile) {
       event.preventDefault();
       setIsSubMenuOpen({ [item]: !isSubMenuOpen[item] });
     }

--- a/src/components/Molecules/Header/Nav/Nav.js
+++ b/src/components/Molecules/Header/Nav/Nav.js
@@ -21,17 +21,13 @@ const MainNav = ({ navItems }) => {
   const [isExpandable, setIsExpandable] = useState(false);
   const [isSubMenuOpen, setIsSubMenuOpen] = useState({});
   const [isKeyPressed, setIsKeyPressed] = useState({});
-  let [width, setWindow] = useState(null);
-  let [mobile, setMobile] = useState(null);
+  let [width] = useState(null);
+  let [mobile] = useState(null);
 
   useEffect(() => {
     // Detect window screen size
     width = window.innerWidth;
     mobile = width < sizes.medium;
-    return () => {
-      setWindow(null);
-      setMobile(null);
-    };
   }, []);
 
   const toggleBurgerMenu = event => {

--- a/src/components/Molecules/Header/Nav/Nav.js
+++ b/src/components/Molecules/Header/Nav/Nav.js
@@ -29,7 +29,7 @@ const MainNav = ({ navItems }) => {
   useEffect(() => {
     // Detect window screen size
     setIsMobile(width < sizes.medium);
-  }, []);
+  });
 
   const toggleBurgerMenu = event => {
     event.preventDefault();

--- a/src/components/Molecules/Header/Nav/Nav.js
+++ b/src/components/Molecules/Header/Nav/Nav.js
@@ -21,15 +21,23 @@ const MainNav = ({ navItems }) => {
   const [isExpandable, setIsExpandable] = useState(false);
   const [isSubMenuOpen, setIsSubMenuOpen] = useState({});
   const [isKeyPressed, setIsKeyPressed] = useState({});
+  let [width, setWindow] = useState(null);
+  let [mobile, setMobile] = useState(null);
+
+  useEffect(() => {
+    // Detect window screen size
+    width = window.innerWidth;
+    mobile = width < sizes.medium;
+    return () => {
+      setWindow(null);
+      setMobile(null);
+    };
+  }, []);
 
   const toggleBurgerMenu = event => {
     event.preventDefault();
     setIsExpandable(!isExpandable);
   };
-
-  // Detect windown screen size
-  const width = window.innerWidth;
-  const mobile = width < sizes.medium;
 
   const toggleSubMenu = item => event => {
     if (mobile) {


### PR DESCRIPTION
Type: patch

Fixes #79 

## Changes proposed in this PR

- Fixes `ReferenceError: window is not defined` during Gatsby build as components are rendered server-side where `window` isn't defined. 
- Solved by accessing `window` after component has mounted or checking if `window` is not `undefined` before accessing it.
