### PR TITLE
font-family as prop in Text component

### DIFF
--- a/src/components/Atoms/Checkbox/Checkbox.test.js
+++ b/src/components/Atoms/Checkbox/Checkbox.test.js
@@ -14,8 +14,10 @@ it('renders correctly', () => {
   expect(tree).toMatchInlineSnapshot(`
     Array [
       .c2 {
+      font-size: 1rem;
       text-transform: inherit;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c1 {
@@ -80,13 +82,16 @@ it('renders correctly', () => {
         <span
           className="c2"
           color="inherit"
+          size="s"
         >
           Tenis
         </span>
       </label>,
       .c2 {
+      font-size: 1rem;
       text-transform: inherit;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c1 {
@@ -151,6 +156,7 @@ it('renders correctly', () => {
         <span
           className="c2"
           color="inherit"
+          size="s"
         >
           Handball
         </span>

--- a/src/components/Atoms/Input/input.test.js
+++ b/src/components/Atoms/Input/input.test.js
@@ -17,8 +17,10 @@ it('renders correctly', () => {
 
   expect(tree).toMatchInlineSnapshot(`
     .c1 {
+      font-size: 1rem;
       text-transform: inherit;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c2 {
@@ -81,6 +83,7 @@ it('renders correctly', () => {
       <span
         className="c1"
         color="inherit"
+        size="s"
       >
         Label
       </span>

--- a/src/components/Atoms/RadioButton/RadioButton.test.js
+++ b/src/components/Atoms/RadioButton/RadioButton.test.js
@@ -14,8 +14,10 @@ it('renders correctly', () => {
   expect(tree).toMatchInlineSnapshot(`
     Array [
       .c2 {
+      font-size: 1rem;
       text-transform: inherit;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c1 {
@@ -88,13 +90,16 @@ it('renders correctly', () => {
         <span
           className="c2"
           color="inherit"
+          size="s"
         >
           Male
         </span>
       </label>,
       .c2 {
+      font-size: 1rem;
       text-transform: inherit;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c1 {
@@ -167,6 +172,7 @@ it('renders correctly', () => {
         <span
           className="c2"
           color="inherit"
+          size="s"
         >
           Female
         </span>

--- a/src/components/Atoms/SelectField/SelectField.test.js
+++ b/src/components/Atoms/SelectField/SelectField.test.js
@@ -23,8 +23,10 @@ it('renders correctly', () => {
 
   expect(tree).toMatchInlineSnapshot(`
     .c1 {
+      font-size: 1rem;
       text-transform: inherit;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c2 {
@@ -78,6 +80,7 @@ it('renders correctly', () => {
       <span
         className="c1"
         color="inherit"
+        size="s"
       >
         Label
       </span>

--- a/src/components/Atoms/Text/Text.js
+++ b/src/components/Atoms/Text/Text.js
@@ -2,9 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-/**
- * Text component
- */
+/** Text component */
 export const BaseText = styled.span`
   color: ${({ color, theme }) => (color ? theme.color(color) : 'inherit')};
   font-size: ${({ size, theme }) => theme.fontSize(size)};
@@ -14,9 +12,11 @@ export const BaseText = styled.span`
     family ? theme.fontFamilies(family) : 'inherit'};
 `;
 
-/** Text renders different elements based on the `tag` prop */
+/** Text renders different elements based on the `tag` prop
+ *  Weight is checked for existence to prevent overriding the tag's css
+ */
 const Text = ({ tag, children, weight, family, ...rest }) => (
-  <BaseText {...rest} as={tag} weight={weight} family={family}>
+  <BaseText {...rest} as={tag} weight={weight && weight} family={family}>
     {children}
   </BaseText>
 );
@@ -24,7 +24,7 @@ const Text = ({ tag, children, weight, family, ...rest }) => (
 Text.defaultProps = {
   family: 'Montserrat',
   tag: 'span',
-  weight: 'normal',
+  weight: null,
   uppercase: false,
   size: 's',
   color: 'inherit'

--- a/src/components/Atoms/Text/Text.js
+++ b/src/components/Atoms/Text/Text.js
@@ -10,23 +10,29 @@ export const BaseText = styled.span`
   font-size: ${({ size, theme }) => theme.fontSize(size)};
   text-transform: ${({ uppercase }) => (uppercase ? 'uppercase' : 'inherit')};
   font-weight: ${({ weight }) => weight};
+  font-family: ${({ family, theme }) =>
+    family ? theme.fontFamilies(family) : 'inherit'};
 `;
 
 /** Text renders different elements based on the `tag` prop */
-const Text = ({ tag, children, weight, ...rest }) => (
-  <BaseText {...rest} as={tag} weight={weight}>
+const Text = ({ tag, children, weight, family, ...rest }) => (
+  <BaseText {...rest} as={tag} weight={weight} family={family}>
     {children}
   </BaseText>
 );
 
 Text.defaultProps = {
+  family: 'Montserrat',
   tag: 'span',
   weight: 'normal',
   uppercase: false,
-  size: 's'
+  size: 's',
+  color: 'inherit'
 };
 
 Text.propTypes = {
+  /** Font family **/
+  family: PropTypes.string,
   /** Weight of Font */
   weight: PropTypes.string,
   /** Sets text transform to uppercase. */
@@ -42,10 +48,6 @@ Text.propTypes = {
     PropTypes.node,
     PropTypes.string
   ]).isRequired
-};
-
-Text.defaultProps = {
-  color: 'inherit'
 };
 
 export default Text;

--- a/src/components/Atoms/Text/Text.js
+++ b/src/components/Atoms/Text/Text.js
@@ -31,7 +31,7 @@ Text.defaultProps = {
 };
 
 Text.propTypes = {
-  /** Font family **/
+  /** Font family */
   family: PropTypes.string,
   /** Weight of Font */
   weight: PropTypes.string,

--- a/src/components/Atoms/Text/Text.md
+++ b/src/components/Atoms/Text/Text.md
@@ -13,7 +13,7 @@
     My paragraph xl and yellow
   </Text>
   <Text tag="p" size="xl" family="Anton">
-    Paragraph xl and font Anton
+    Paragraph size xl and font Anton
   </Text>
 </div>
 ```
@@ -32,7 +32,7 @@ Sport Relief
     Heading 3 size 3
   </Text>
   <Text tag="p" size="xl" color="red">
-    My paragraph small and yellow
+    My paragraph small and red
   </Text>
 </div>
 ```

--- a/src/components/Atoms/Text/Text.md
+++ b/src/components/Atoms/Text/Text.md
@@ -13,7 +13,7 @@
     My paragraph xl and yellow
   </Text>
   <Text tag="p" size="xl" family="Anton">
-    Paragraph xl and font anton
+    Paragraph xl and font Anton
   </Text>
 </div>
 ```

--- a/src/components/Atoms/Text/Text.md
+++ b/src/components/Atoms/Text/Text.md
@@ -12,6 +12,9 @@
   <Text tag="p" size="xl" color="yellow">
     My paragraph xl and yellow
   </Text>
+  <Text tag="p" size="xl" family="Anton">
+    Paragraph xl and font anton
+  </Text>
 </div>
 ```
 

--- a/src/components/Atoms/Text/Text.test.js
+++ b/src/components/Atoms/Text/Text.test.js
@@ -5,24 +5,28 @@ import Text from './Text';
 
 it('renders correctly', () => {
   const tree = renderWithTheme(
-    <Text tag="p" size="xl" color="yellow">
-      My paragraph small and yellow
+    <Text tag="p" size="xl" color="yellow" family="Anton">
+      My paragraph extra large, yellow and font family Anton
     </Text>
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
     .c0 {
       color: #FFE400;
+      font-weight: normal;
+      font-family: 'Anton',Impact,sans-serif;
       font-size: 1.725rem;
       text-transform: inherit;
+      
     }
 
     <p
       className="c0"
       color="yellow"
+      family="Anton"
       size="xl"
     >
-      My paragraph small and yellow
+      My paragraph extra large, yellow and font family Anton
     </p>
   `);
 });

--- a/src/components/Atoms/Text/Text.test.js
+++ b/src/components/Atoms/Text/Text.test.js
@@ -13,17 +13,15 @@ it('renders correctly', () => {
   expect(tree).toMatchInlineSnapshot(`
     .c0 {
       color: #FFE400;
-      font-weight: normal;
-      font-family: 'Anton',Impact,sans-serif;
       font-size: 1.725rem;
       text-transform: inherit;
-      
+      font-weight: normal;
+      font-family: 'Anton',Impact,sans-serif;
     }
 
     <p
       className="c0"
       color="yellow"
-      family="Anton"
       size="xl"
     >
       My paragraph extra large, yellow and font family Anton

--- a/src/components/Atoms/Text/Text.test.js
+++ b/src/components/Atoms/Text/Text.test.js
@@ -15,7 +15,6 @@ it('renders correctly', () => {
       color: #FFE400;
       font-size: 1.725rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Anton',Impact,sans-serif;
     }
 

--- a/src/components/Atoms/TextArea/TextArea.test.js
+++ b/src/components/Atoms/TextArea/TextArea.test.js
@@ -18,8 +18,10 @@ it('renders correctly', () => {
 
   expect(tree).toMatchInlineSnapshot(`
     .c1 {
+      font-size: 1rem;
       text-transform: inherit;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c2 {
@@ -100,6 +102,7 @@ it('renders correctly', () => {
       <span
         className="c1"
         color="inherit"
+        size="s"
       >
         Label
       </span>

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -30,7 +30,6 @@ it('renders correctly', () => {
     .c7 {
       font-size: 1.725rem;
       text-transform: uppercase;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -24,11 +24,14 @@ it('renders correctly', () => {
       font-size: 0.69375rem;
       text-transform: uppercase;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c7 {
       font-size: 1.725rem;
       text-transform: uppercase;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c3 {

--- a/src/components/Molecules/CookieBanner/CookieBanner.test.js
+++ b/src/components/Molecules/CookieBanner/CookieBanner.test.js
@@ -21,7 +21,10 @@ it('renders correctly', () => {
   expect(tree).toMatchInlineSnapshot(`
     .c2 {
       color: #FFFFFF;
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c4 {
@@ -123,6 +126,7 @@ it('renders correctly', () => {
       <p
         className="c1 c2"
         color="white"
+        size="s"
       >
         Hello! Comic Relief uses cookies to help make this website better and improve our services. You can learn more about our use of cookies
         <a
@@ -139,6 +143,7 @@ it('renders correctly', () => {
       <p
         className="c1 c2"
         color="white"
+        size="s"
       >
         <a
           className="c5 c6"

--- a/src/components/Molecules/CookieBanner/CookieBanner.test.js
+++ b/src/components/Molecules/CookieBanner/CookieBanner.test.js
@@ -23,7 +23,6 @@ it('renders correctly', () => {
       color: #FFFFFF;
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 

--- a/src/components/Molecules/EmailSignUp/EmailSignUp.test.js
+++ b/src/components/Molecules/EmailSignUp/EmailSignUp.test.js
@@ -40,12 +40,17 @@ it('renders correctly', () => {
   expect(tree).toMatchInlineSnapshot(`
     Array [
       .c1 {
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c7 {
+      font-size: 1rem;
       text-transform: inherit;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c11 {
@@ -225,6 +230,7 @@ it('renders correctly', () => {
         <h1
           className="c1"
           color="inherit"
+          size="s"
         >
           sign up letter
         </h1>
@@ -250,6 +256,7 @@ it('renders correctly', () => {
             <span
               className="c6 c7"
               color="inherit"
+              size="s"
             >
               email
             </span>
@@ -292,7 +299,10 @@ it('renders correctly', () => {
         </div>
       </div>,
       .c1 {
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c3 {
@@ -327,6 +337,7 @@ it('renders correctly', () => {
         <h1
           className="c1"
           color="inherit"
+          size="s"
         >
           sign up letter
         </h1>

--- a/src/components/Molecules/EmailSignUp/EmailSignUp.test.js
+++ b/src/components/Molecules/EmailSignUp/EmailSignUp.test.js
@@ -42,7 +42,6 @@ it('renders correctly', () => {
       .c1 {
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
@@ -301,7 +300,6 @@ it('renders correctly', () => {
       .c1 {
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 

--- a/src/components/Molecules/Footer/Footer.test.js
+++ b/src/components/Molecules/Footer/Footer.test.js
@@ -16,7 +16,6 @@ it('renders correctly', () => {
     .c7 {
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
@@ -24,7 +23,6 @@ it('renders correctly', () => {
       color: #FFFFFF;
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 

--- a/src/components/Molecules/Footer/Footer.test.js
+++ b/src/components/Molecules/Footer/Footer.test.js
@@ -14,12 +14,18 @@ it('renders correctly', () => {
 
   expect(tree).toMatchInlineSnapshot(`
     .c7 {
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c21 {
       color: #FFFFFF;
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c19 {
@@ -548,6 +554,7 @@ it('renders correctly', () => {
             className="c7"
             color="inherit"
             id="footer-menu"
+            size="s"
           >
             Footer navigation
           </h2>
@@ -572,6 +579,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   Hear from us
                 </span>
@@ -595,6 +603,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Get the newsletter
                     </span>
@@ -614,6 +623,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       How we contact you
                     </span>
@@ -638,6 +648,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   Get in touch
                 </span>
@@ -661,6 +672,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Contact us
                     </span>
@@ -680,6 +692,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Your Gift Aid
                     </span>
@@ -699,6 +712,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       FAQs
                     </span>
@@ -718,6 +732,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Red Nose Day 2019 FAQs
                     </span>
@@ -742,6 +757,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   About us
                 </span>
@@ -765,6 +781,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Mission
                     </span>
@@ -784,6 +801,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Our history
                     </span>
@@ -803,6 +821,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Finances
                     </span>
@@ -822,6 +841,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Partners
                     </span>
@@ -841,6 +861,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Meet the team
                     </span>
@@ -860,6 +881,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Sport Relief
                     </span>
@@ -884,6 +906,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   Careers
                 </span>
@@ -907,6 +930,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Working at Comic Relief
                     </span>
@@ -926,6 +950,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Open roles
                     </span>
@@ -950,6 +975,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   News
                 </span>
@@ -973,6 +999,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       News
                     </span>
@@ -992,6 +1019,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Press area
                     </span>
@@ -1016,6 +1044,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   Legal
                 </span>
@@ -1039,6 +1068,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Link comp with both URL and Ref
                     </span>
@@ -1058,6 +1088,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Link comp with only Ref
                     </span>
@@ -1077,6 +1108,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Link comp with only URL
                     </span>
@@ -1096,6 +1128,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Test whitelisted external link
                     </span>
@@ -1115,6 +1148,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Test non-whitelisted external link
                     </span>
@@ -1146,6 +1180,7 @@ it('renders correctly', () => {
           <p
             className="c21"
             color="white"
+            size="s"
           >
             Comic Relief is the trading name of Charity Projects, a registered charity in England and Wales (326568) and Scotland (SC039730), which is a company limited by guarantee registered in England and Wales (01806414). Registered address: 1st Floor, 89 Albert Embankment, London, SE1 7TP.
           </p>

--- a/src/components/Molecules/Header/header.test.js
+++ b/src/components/Molecules/Header/header.test.js
@@ -21,7 +21,10 @@ it('renders correctly', () => {
 
   expect(tree).toMatchInlineSnapshot(`
     .c7 {
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c5 {
@@ -542,6 +545,7 @@ it('renders correctly', () => {
             className="c7"
             color="inherit"
             id="main-menu"
+            size="s"
           >
             Main navigation
           </h2>
@@ -566,6 +570,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   Fundraising
                 </span>
@@ -589,6 +594,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Fundraising
                     </span>
@@ -608,6 +614,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Red Nose Day
                     </span>
@@ -627,6 +634,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Regular donations
                     </span>
@@ -646,6 +654,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Squads
                     </span>
@@ -665,6 +674,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       The Noseys
                     </span>
@@ -684,6 +694,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Free downloads
                     </span>
@@ -708,6 +719,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   What your money does
                 </span>
@@ -731,6 +743,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       What your money does
                     </span>
@@ -750,6 +763,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Our legacy
                     </span>
@@ -774,6 +788,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   Schools & youth
                 </span>
@@ -797,6 +812,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Schools & youth
                     </span>
@@ -816,6 +832,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Primary schools
                     </span>
@@ -835,6 +852,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Secondary schools
                     </span>
@@ -854,6 +872,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Nurseries
                     </span>
@@ -873,6 +892,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Youth groups
                     </span>
@@ -892,6 +912,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Free downloads
                     </span>
@@ -916,6 +937,7 @@ it('renders correctly', () => {
                 <span
                   className="c7"
                   color="inherit"
+                  size="s"
                 >
                   Test whitelisted external link
                 </span>
@@ -939,6 +961,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Test whitelisted external link
                     </span>
@@ -958,6 +981,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Test non-whitelisted external link
                     </span>
@@ -977,6 +1001,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Link comp: URL and Ref
                     </span>
@@ -996,6 +1021,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Link comp: only Ref
                     </span>
@@ -1015,6 +1041,7 @@ it('renders correctly', () => {
                     <span
                       className="c7"
                       color="inherit"
+                      size="s"
                     >
                       Link comp: only URL
                     </span>
@@ -1038,6 +1065,7 @@ it('renders correctly', () => {
           <span
             className="c18 c7"
             color="inherit"
+            size="s"
           >
             Open and close nav menu
           </span>

--- a/src/components/Molecules/Header/header.test.js
+++ b/src/components/Molecules/Header/header.test.js
@@ -23,7 +23,6 @@ it('renders correctly', () => {
     .c7 {
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 

--- a/src/components/Molecules/PartnerLink/PartnerLink.test.js
+++ b/src/components/Molecules/PartnerLink/PartnerLink.test.js
@@ -18,7 +18,6 @@ it('renders correctly', () => {
       color: #FFFFFF;
       font-size: 0.69375rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 

--- a/src/components/Molecules/PartnerLink/PartnerLink.test.js
+++ b/src/components/Molecules/PartnerLink/PartnerLink.test.js
@@ -18,6 +18,8 @@ it('renders correctly', () => {
       color: #FFFFFF;
       font-size: 0.69375rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c2 {

--- a/src/components/Molecules/SearchInput/SearchInput.test.js
+++ b/src/components/Molecules/SearchInput/SearchInput.test.js
@@ -16,8 +16,10 @@ it('renders correctly', () => {
 
   expect(tree).toMatchInlineSnapshot(`
     .c6 {
+      font-size: 1rem;
       text-transform: inherit;
       font-weight: bold;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c8 {
@@ -210,6 +212,7 @@ it('renders correctly', () => {
               <span
                 className="c5 c6"
                 color="inherit"
+                size="s"
               >
                 Search
               </span>
@@ -235,6 +238,7 @@ it('renders correctly', () => {
               <span
                 className="c5 c6"
                 color="inherit"
+                size="s"
               >
                 
               </span>

--- a/src/components/Molecules/SearchResult/__snapshots__/SearchResult.test.js.snap
+++ b/src/components/Molecules/SearchResult/__snapshots__/SearchResult.test.js.snap
@@ -4,11 +4,15 @@ exports[`renders correctly in minimalist form 1`] = `
 .c7 {
   font-size: 0.83125rem;
   text-transform: uppercase;
+  font-weight: normal;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c9 {
   font-size: 1.725rem;
   text-transform: uppercase;
+  font-weight: normal;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c4 {
@@ -165,16 +169,22 @@ exports[`renders correctly with copy 1`] = `
 .c7 {
   font-size: 0.83125rem;
   text-transform: uppercase;
+  font-weight: normal;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c9 {
   font-size: 1.725rem;
   text-transform: uppercase;
+  font-weight: normal;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c10 {
   font-size: 1.2rem;
   text-transform: inherit;
+  font-weight: normal;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c4 {
@@ -337,11 +347,15 @@ exports[`renders correctly with date 1`] = `
 .c7 {
   font-size: 0.83125rem;
   text-transform: uppercase;
+  font-weight: normal;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c9 {
   font-size: 1.725rem;
   text-transform: uppercase;
+  font-weight: normal;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c4 {
@@ -498,11 +512,15 @@ exports[`renders correctly with date and type 1`] = `
 .c7 {
   font-size: 0.83125rem;
   text-transform: uppercase;
+  font-weight: normal;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c9 {
   font-size: 1.725rem;
   text-transform: uppercase;
+  font-weight: normal;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c4 {

--- a/src/components/Molecules/SearchResult/__snapshots__/SearchResult.test.js.snap
+++ b/src/components/Molecules/SearchResult/__snapshots__/SearchResult.test.js.snap
@@ -4,14 +4,12 @@ exports[`renders correctly in minimalist form 1`] = `
 .c7 {
   font-size: 0.83125rem;
   text-transform: uppercase;
-  font-weight: normal;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c9 {
   font-size: 1.725rem;
   text-transform: uppercase;
-  font-weight: normal;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
@@ -169,21 +167,18 @@ exports[`renders correctly with copy 1`] = `
 .c7 {
   font-size: 0.83125rem;
   text-transform: uppercase;
-  font-weight: normal;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c9 {
   font-size: 1.725rem;
   text-transform: uppercase;
-  font-weight: normal;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c10 {
   font-size: 1.2rem;
   text-transform: inherit;
-  font-weight: normal;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
@@ -347,14 +342,12 @@ exports[`renders correctly with date 1`] = `
 .c7 {
   font-size: 0.83125rem;
   text-transform: uppercase;
-  font-weight: normal;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c9 {
   font-size: 1.725rem;
   text-transform: uppercase;
-  font-weight: normal;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
@@ -512,14 +505,12 @@ exports[`renders correctly with date and type 1`] = `
 .c7 {
   font-size: 0.83125rem;
   text-transform: uppercase;
-  font-weight: normal;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
 .c9 {
   font-size: 1.725rem;
   text-transform: uppercase;
-  font-weight: normal;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 

--- a/src/components/Molecules/SingleMessage/SingleMessage.test.js
+++ b/src/components/Molecules/SingleMessage/SingleMessage.test.js
@@ -32,11 +32,16 @@ it('renders correctly', () => {
       color: #FFFFFF;
       font-size: 2.075rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c7 {
       color: #FFFFFF;
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c3 {
@@ -173,6 +178,7 @@ it('renders correctly', () => {
         <p
           className="c7"
           color="white"
+          size="s"
         >
           description
         </p>
@@ -202,7 +208,10 @@ it('renders Single Message with no Image correctly', () => {
   expect(tree).toMatchInlineSnapshot(`
     .c2 {
       color: #FFFFFF;
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c0 {
@@ -263,6 +272,7 @@ it('renders Single Message with no Image correctly', () => {
         <p
           className="c2"
           color="white"
+          size="s"
         >
           description
         </p>
@@ -283,7 +293,10 @@ it('renders fullWidth Single Message correctly', () => {
   expect(tree).toMatchInlineSnapshot(`
     .c2 {
       color: #FFFFFF;
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c0 {
@@ -344,6 +357,7 @@ it('renders fullWidth Single Message correctly', () => {
         <p
           className="c2"
           color="white"
+          size="s"
         >
           description
         </p>
@@ -373,7 +387,10 @@ it('renders double image Single Message correctly', () => {
   expect(tree).toMatchInlineSnapshot(`
     .c6 {
       color: #FFFFFF;
+      font-size: 1rem;
       text-transform: inherit;
+      font-weight: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
     .c3 {
@@ -507,6 +524,7 @@ it('renders double image Single Message correctly', () => {
         <p
           className="c6"
           color="white"
+          size="s"
         >
           description
         </p>

--- a/src/components/Molecules/SingleMessage/SingleMessage.test.js
+++ b/src/components/Molecules/SingleMessage/SingleMessage.test.js
@@ -32,7 +32,6 @@ it('renders correctly', () => {
       color: #FFFFFF;
       font-size: 2.075rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
@@ -40,7 +39,6 @@ it('renders correctly', () => {
       color: #FFFFFF;
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
@@ -210,7 +208,6 @@ it('renders Single Message with no Image correctly', () => {
       color: #FFFFFF;
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
@@ -295,7 +292,6 @@ it('renders fullWidth Single Message correctly', () => {
       color: #FFFFFF;
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 
@@ -389,7 +385,6 @@ it('renders double image Single Message correctly', () => {
       color: #FFFFFF;
       font-size: 1rem;
       text-transform: inherit;
-      font-weight: normal;
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
     }
 

--- a/src/theme/crTheme/theme.js
+++ b/src/theme/crTheme/theme.js
@@ -3,11 +3,13 @@ import buttonColors from './buttonColors';
 import linkStyles from './linkStyles';
 import fontSize from './fontSizes';
 import breakpoint from '../shared/breakpoint';
+import fontFamilies from '../shared/fontFamilies';
 
 export default {
   color,
   buttonColors,
   linkStyles,
   fontSize,
-  breakpoint
+  breakpoint,
+  fontFamilies
 };

--- a/src/theme/shared/fontFamilies.js
+++ b/src/theme/shared/fontFamilies.js
@@ -1,5 +1,3 @@
-// import { css } from 'styled-components';
-
 const fontFamilies = {
   Montserrat: { font: 'Montserrat', fallback: 'Helvetica, Arial' },
   Anton: { font: 'Anton', fallback: 'Impact' }

--- a/src/theme/shared/fontFamilies.js
+++ b/src/theme/shared/fontFamilies.js
@@ -1,0 +1,14 @@
+// import { css } from 'styled-components';
+
+const fontFamilies = {
+  Montserrat: { font: 'Montserrat', fallback: 'Helvetica, Arial' },
+  Anton: { font: 'Anton', fallback: 'Impact' }
+};
+
+export default family => {
+  let style = 'inherit';
+  if (family) {
+    style = `'${fontFamilies[family].font}', ${fontFamilies[family].fallback}, sans-serif`;
+  }
+  return style;
+};


### PR DESCRIPTION
Type: patch

Fixes #133 

- add fontFamilies to shared theme
- add font family as a prop to Text component and get font family from theme
- update all tests where Text is used