### PR TITLE
fix: cookie banner SEO error due to not using descriptive text in link

### DIFF
--- a/src/components/Molecules/CookieBanner/CookieBanner.js
+++ b/src/components/Molecules/CookieBanner/CookieBanner.js
@@ -12,10 +12,11 @@ const CookieBanner = ({ acceptCookie, denyCookie, cookiePolicyUrl }) => {
   return (
     <CookieWrapper>
       <CookieText tag="p" color="white">
-        Hello! Comic Relief uses cookies to help make this website better and
-        improve our services. You can learn more about our use of cookies
+        {
+          'Hello! Comic Relief uses cookies to help make this website better and improve our services. You can learn more about '
+        }
         <LinkStyle href={cookiePolicyUrl} type="standard_white">
-          here
+          our use of cookies
         </LinkStyle>
         . We also use optional cookies for marketing purposes:
       </CookieText>

--- a/src/components/Molecules/CookieBanner/CookieBanner.test.js
+++ b/src/components/Molecules/CookieBanner/CookieBanner.test.js
@@ -127,7 +127,7 @@ it('renders correctly', () => {
         color="white"
         size="s"
       >
-        Hello! Comic Relief uses cookies to help make this website better and improve our services. You can learn more about our use of cookies
+        Hello! Comic Relief uses cookies to help make this website better and improve our services. You can learn more about 
         <a
           className="c3 c4"
           color="red"
@@ -135,7 +135,7 @@ it('renders correctly', () => {
           target="_self"
           type="standard_white"
         >
-          here
+          our use of cookies
         </a>
         . We also use optional cookies for marketing purposes:
       </p>


### PR DESCRIPTION
Type: patch

Fixes comicrelief/comicrelief-contentful#61 specifically https://comicrelief-contentful-lighthouse.s3.amazonaws.com/61-cookie/index.html

