### PR TITLE
fix: header menu getting hidden behind play button on small devices

### DIFF
--- a/src/components/Molecules/Header/Nav/Nav.style.js
+++ b/src/components/Molecules/Header/Nav/Nav.style.js
@@ -29,7 +29,7 @@ const Nav = styled.nav`
   position: absolute;
   top: 75px;
   left: 0;
-  ${zIndex('medium')};
+  ${zIndex('higher')};
 
   @media (min-width: ${screen.small}) {
     width: 50%;

--- a/src/components/Molecules/Header/header.test.js
+++ b/src/components/Molecules/Header/header.test.js
@@ -188,7 +188,7 @@ it('renders correctly', () => {
       position: absolute;
       top: 75px;
       left: 0;
-      z-index: 2;
+      z-index: 4;
     }
 
     .c6 > h2 {

--- a/src/theme/shared/zIndex.js
+++ b/src/theme/shared/zIndex.js
@@ -4,7 +4,8 @@ const indexes = {
   base: 0,
   low: 1,
   medium: 2,
-  high: 3
+  high: 3,
+  higher: 4
 };
 
 const zIndex = index => {


### PR DESCRIPTION
Type: patch

Fixes comicrelief/comicrelief-contentful#278

## Changes proposed in this PR

- Increase menu z-index to raise it above play button.
