### PR TITLE
fix: Remove label confusing attributes

### DIFF
--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -77,8 +77,18 @@ const TextLabel = styled(Text)`
 
 const Input = ({ errorMsg, id, label, showLabel, type, hasAria, ...rest }) => {
   const error = errorMsg && errorMsg.length > 0;
+  const labelRest = { ...rest };
+  // Remove unrelated attributes to label element
+  Object.keys(labelRest).map(propKey => {
+    if (['value', 'name', 'placeholder', 'role'].includes(propKey)) {
+      delete labelRest[propKey];
+    } else if (propKey.match(/^aria-/) && propKey !== 'aria-label') {
+      delete labelRest[propKey];
+    }
+    return true;
+  });
   return (
-    <Label htmlFor={id} {...rest}>
+    <Label htmlFor={id} {...labelRest}>
       <TextLabel showLabel={showLabel} weight="bold">
         {label}
       </TextLabel>

--- a/src/components/Atoms/Input/input.test.js
+++ b/src/components/Atoms/Input/input.test.js
@@ -80,8 +80,6 @@ it('renders correctly', () => {
     <label
       className="c0"
       htmlFor="Accessibility info go here"
-      name="fullname"
-      placeholder="This is the hint text"
     >
       <span
         className="c1 "

--- a/src/components/Molecules/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Molecules/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -479,10 +479,7 @@ exports[`renders correctly 1`] = `
     <label
       className="c6 c7"
       htmlFor="email"
-      name="email"
       onChange={[Function]}
-      placeholder="example@youremail.com"
-      value=""
     >
       <span
         className="c8 c9"

--- a/src/components/Molecules/HeaderEsuWithIcon/__snapshots__/HeaderEsuWithIcon.test.js.snap
+++ b/src/components/Molecules/HeaderEsuWithIcon/__snapshots__/HeaderEsuWithIcon.test.js.snap
@@ -346,10 +346,7 @@ exports[`renders correctly with error message 1`] = `
           <label
             className="c11 c12"
             htmlFor="email"
-            name="email"
             onChange={[Function]}
-            placeholder="example@youremail.com"
-            value=""
           >
             <span
               className="c13 c14"
@@ -796,10 +793,7 @@ exports[`renders correctly with modal open 1`] = `
           <label
             className="c11 c12"
             htmlFor="email"
-            name="email"
             onChange={[Function]}
-            placeholder="example@youremail.com"
-            value=""
           >
             <span
               className="c13 c14"

--- a/src/components/Molecules/Membership/Membership.test.js
+++ b/src/components/Molecules/Membership/Membership.test.js
@@ -433,10 +433,7 @@ it('renders correctly', () => {
                 aria-label="a regular supply of toiletries for someone living in a refugee camp in Serbia."
                 className="c11 c12"
                 htmlFor="moneyBuy-box1"
-                name="moneyBuy1"
                 onClick={[Function]}
-                placeholder=""
-                value="£ 5"
               >
                 <span
                   className="c13 "
@@ -462,10 +459,7 @@ it('renders correctly', () => {
                 aria-label="a potentially lifesaving call for a man at risk of suicide in the UK."
                 className="c11 c15"
                 htmlFor="moneyBuy-box2"
-                name="moneyBuy2"
                 onClick={[Function]}
-                placeholder=""
-                value="£ 10"
               >
                 <span
                   className="c13 "
@@ -491,10 +485,7 @@ it('renders correctly', () => {
                 aria-label="the distribution of enough surplus food for a school breakfast club to feed 80 children."
                 className="c11 c12"
                 htmlFor="moneyBuy-box3"
-                name="moneyBuy3"
                 onClick={[Function]}
-                placeholder=""
-                value="£ 20"
               >
                 <span
                   className="c13 "
@@ -532,14 +523,11 @@ it('renders correctly', () => {
                 htmlFor="MoneyBuy-userInput"
                 max="5000"
                 min="1"
-                name="membership_amount"
                 onChange={[Function]}
                 onClick={[Function]}
                 onKeyPress={[Function]}
                 pattern="[^[0-9]+([,.][0-9]+)?$]"
-                placeholder="0.00"
                 step="0.01"
-                value=""
               >
                 <span
                   className="c13 "

--- a/src/components/Molecules/SearchInput/SearchInput.test.js
+++ b/src/components/Molecules/SearchInput/SearchInput.test.js
@@ -214,10 +214,7 @@ it('renders correctly', () => {
             <label
               className="c4 c5"
               htmlFor="search"
-              name="search"
               onChange={[Function]}
-              placeholder=""
-              value=""
             >
               <span
                 className="c6 c7"
@@ -246,8 +243,6 @@ it('renders correctly', () => {
               className="c4 c10"
               disabled="disabled"
               htmlFor=""
-              name="action"
-              placeholder=""
             >
               <span
                 className="c6 c7"


### PR DESCRIPTION
Type: patch

Fixes comicrelief/comicrelief-contentful#490

## Changes proposed in this PR

- Accessibility fails when input attributes are present in label as well, so extra ones are now removed from label.
