### PR TITLE
Fix: Issue with Input component duplicating props & adding event handlers twice

### DIFF
--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -81,13 +81,14 @@ const Input = ({
   showLabel,
   type,
   hasAria,
+  className,
   labelProps,
   ...rest
 }) => {
   const error = errorMsg && errorMsg.length > 0;
 
   return (
-    <Label htmlFor={id} {...labelProps}>
+    <Label htmlFor={id} className={className} {...labelProps}>
       <TextLabel showLabel={showLabel} weight="bold">
         {label}
       </TextLabel>
@@ -117,7 +118,8 @@ Input.propTypes = {
   id: PropTypes.string.isRequired,
   /** text, email, number, date, serach, tel, url, password */
   type: PropTypes.string.isRequired,
-  labelProps: PropTypes.objectOf(PropTypes.any)
+  labelProps: PropTypes.objectOf(PropTypes.any),
+  className: PropTypes.string
 };
 
 Input.defaultProps = {
@@ -125,7 +127,8 @@ Input.defaultProps = {
   hasAria: true,
   placeholder: '',
   errorMsg: '',
-  labelProps: {}
+  labelProps: {},
+  className: ''
 };
 
 export default Input;

--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -57,7 +57,6 @@ const ErrorText = styled(Text)`
     position: relative;
     content: '';
     top: 2px;
-    vertical-align: middle;
     margin-right: 6px;
     background: url(${alertIcon}) left 0/100% no-repeat;
     width: 18px;
@@ -75,20 +74,20 @@ const TextLabel = styled(Text)`
   visibility: ${({ showLabel }) => !showLabel && hideVisually};
 `;
 
-const Input = ({ errorMsg, id, label, showLabel, type, hasAria, ...rest }) => {
+const Input = ({
+  errorMsg,
+  id,
+  label,
+  showLabel,
+  type,
+  hasAria,
+  labelProps,
+  ...rest
+}) => {
   const error = errorMsg && errorMsg.length > 0;
-  const labelRest = { ...rest };
-  // Remove unrelated attributes to label element
-  Object.keys(labelRest).map(propKey => {
-    if (['value', 'name', 'placeholder', 'role'].includes(propKey)) {
-      delete labelRest[propKey];
-    } else if (propKey.match(/^aria-/) && propKey !== 'aria-label') {
-      delete labelRest[propKey];
-    }
-    return true;
-  });
+
   return (
-    <Label htmlFor={id} {...labelRest}>
+    <Label htmlFor={id} {...labelProps}>
       <TextLabel showLabel={showLabel} weight="bold">
         {label}
       </TextLabel>
@@ -117,14 +116,16 @@ Input.propTypes = {
   hasAria: PropTypes.bool,
   id: PropTypes.string.isRequired,
   /** text, email, number, date, serach, tel, url, password */
-  type: PropTypes.string.isRequired
+  type: PropTypes.string.isRequired,
+  labelProps: PropTypes.objectOf(PropTypes.any)
 };
 
 Input.defaultProps = {
   showLabel: true,
   hasAria: true,
   placeholder: '',
-  errorMsg: ''
+  errorMsg: '',
+  labelProps: {}
 };
 
 export default Input;

--- a/src/components/Molecules/HeaderEsuWithIcon/__snapshots__/HeaderEsuWithIcon.test.js.snap
+++ b/src/components/Molecules/HeaderEsuWithIcon/__snapshots__/HeaderEsuWithIcon.test.js.snap
@@ -13,7 +13,7 @@ exports[`renders correctly with error message 1`] = `
   letter-spacing: 0.03rem;
 }
 
-.c12 {
+.c13 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -28,7 +28,7 @@ exports[`renders correctly with error message 1`] = `
   font-family: inherit;
 }
 
-.c14 {
+.c15 {
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
   font-weight: 400;
   position: relative;
@@ -46,23 +46,23 @@ exports[`renders correctly with error message 1`] = `
   color: #000000;
 }
 
-.c14:focus {
+.c15:focus {
   border: 1px solid #666;
 }
 
-.c14:focus::-webkit-input-placeholder {
+.c15:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c14:focus::-moz-placeholder {
+.c15:focus::-moz-placeholder {
   color: #666;
 }
 
-.c14:focus:-ms-input-placeholder {
+.c15:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c14:focus::placeholder {
+.c15:focus::placeholder {
   color: #666;
 }
 
@@ -94,7 +94,7 @@ exports[`renders correctly with error message 1`] = `
   color: #E52630;
 }
 
-.c13 {
+.c14 {
   visibility: border:0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -209,7 +209,7 @@ exports[`renders correctly with error message 1`] = `
   margin: 1rem 0;
 }
 
-.c15 {
+.c12 {
   width: 100%;
 }
 
@@ -286,7 +286,7 @@ exports[`renders correctly with error message 1`] = `
 }
 
 @media (min-width:740px) {
-  .c14 {
+  .c15 {
     max-width: 290px;
   }
 }
@@ -378,11 +378,11 @@ exports[`renders correctly with error message 1`] = `
           onSubmit={[Function]}
         >
           <label
-            className="c11"
+            className="c11 c12"
             htmlFor="email"
           >
             <span
-              className="c12 c13"
+              className="c13 c14"
               color="inherit"
               size="s"
             >
@@ -390,7 +390,7 @@ exports[`renders correctly with error message 1`] = `
             </span>
             <input
               aria-label="Email address"
-              className="c14 c15"
+              className="c15"
               id="email"
               name="email"
               onChange={[Function]}
@@ -525,7 +525,7 @@ exports[`renders correctly with modal open 1`] = `
   letter-spacing: 0.03rem;
 }
 
-.c12 {
+.c13 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -534,7 +534,7 @@ exports[`renders correctly with modal open 1`] = `
   font-family: inherit;
 }
 
-.c14 {
+.c15 {
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
   font-weight: 400;
   position: relative;
@@ -552,23 +552,23 @@ exports[`renders correctly with modal open 1`] = `
   color: #000000;
 }
 
-.c14:focus {
+.c15:focus {
   border: 1px solid #666;
 }
 
-.c14:focus::-webkit-input-placeholder {
+.c15:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c14:focus::-moz-placeholder {
+.c15:focus::-moz-placeholder {
   color: #666;
 }
 
-.c14:focus:-ms-input-placeholder {
+.c15:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c14:focus::placeholder {
+.c15:focus::placeholder {
   color: #666;
 }
 
@@ -582,7 +582,7 @@ exports[`renders correctly with modal open 1`] = `
   flex-direction: column;
 }
 
-.c13 {
+.c14 {
   visibility: border:0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -697,7 +697,7 @@ exports[`renders correctly with modal open 1`] = `
   margin: 1rem 0;
 }
 
-.c15 {
+.c12 {
   width: 100%;
 }
 
@@ -774,7 +774,7 @@ exports[`renders correctly with modal open 1`] = `
 }
 
 @media (min-width:740px) {
-  .c14 {
+  .c15 {
     max-width: 290px;
   }
 }
@@ -866,11 +866,11 @@ exports[`renders correctly with modal open 1`] = `
           onSubmit={[Function]}
         >
           <label
-            className="c11"
+            className="c11 c12"
             htmlFor="email"
           >
             <span
-              className="c12 c13"
+              className="c13 c14"
               color="inherit"
               size="s"
             >
@@ -878,7 +878,7 @@ exports[`renders correctly with modal open 1`] = `
             </span>
             <input
               aria-label="Email address"
-              className="c14 c15"
+              className="c15"
               id="email"
               name="email"
               onChange={[Function]}

--- a/src/components/Molecules/HeaderEsuWithIcon/__snapshots__/HeaderEsuWithIcon.test.js.snap
+++ b/src/components/Molecules/HeaderEsuWithIcon/__snapshots__/HeaderEsuWithIcon.test.js.snap
@@ -13,7 +13,7 @@ exports[`renders correctly with error message 1`] = `
   letter-spacing: 0.03rem;
 }
 
-.c13 {
+.c12 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -28,7 +28,7 @@ exports[`renders correctly with error message 1`] = `
   font-family: inherit;
 }
 
-.c15 {
+.c14 {
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
   font-weight: 400;
   position: relative;
@@ -46,23 +46,23 @@ exports[`renders correctly with error message 1`] = `
   color: #000000;
 }
 
-.c15:focus {
+.c14:focus {
   border: 1px solid #666;
 }
 
-.c15:focus::-webkit-input-placeholder {
+.c14:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c15:focus::-moz-placeholder {
+.c14:focus::-moz-placeholder {
   color: #666;
 }
 
-.c15:focus:-ms-input-placeholder {
+.c14:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c15:focus::placeholder {
+.c14:focus::placeholder {
   color: #666;
 }
 
@@ -85,7 +85,6 @@ exports[`renders correctly with error message 1`] = `
   position: relative;
   content: '';
   top: 2px;
-  vertical-align: middle;
   margin-right: 6px;
   background: url(mock.asset) left 0/100% no-repeat;
   width: 18px;
@@ -95,7 +94,7 @@ exports[`renders correctly with error message 1`] = `
   color: #E52630;
 }
 
-.c14 {
+.c13 {
   visibility: border:0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -210,7 +209,7 @@ exports[`renders correctly with error message 1`] = `
   margin: 1rem 0;
 }
 
-.c12 {
+.c15 {
   width: 100%;
 }
 
@@ -287,7 +286,7 @@ exports[`renders correctly with error message 1`] = `
 }
 
 @media (min-width:740px) {
-  .c15 {
+  .c14 {
     max-width: 290px;
   }
 }
@@ -379,13 +378,11 @@ exports[`renders correctly with error message 1`] = `
           onSubmit={[Function]}
         >
           <label
-            aria-label="Email address"
-            className="c11 c12"
+            className="c11"
             htmlFor="email"
-            onChange={[Function]}
           >
             <span
-              className="c13 c14"
+              className="c12 c13"
               color="inherit"
               size="s"
             >
@@ -393,7 +390,7 @@ exports[`renders correctly with error message 1`] = `
             </span>
             <input
               aria-label="Email address"
-              className="c15 c12"
+              className="c14 c15"
               id="email"
               name="email"
               onChange={[Function]}
@@ -528,7 +525,7 @@ exports[`renders correctly with modal open 1`] = `
   letter-spacing: 0.03rem;
 }
 
-.c13 {
+.c12 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -537,7 +534,7 @@ exports[`renders correctly with modal open 1`] = `
   font-family: inherit;
 }
 
-.c15 {
+.c14 {
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
   font-weight: 400;
   position: relative;
@@ -555,23 +552,23 @@ exports[`renders correctly with modal open 1`] = `
   color: #000000;
 }
 
-.c15:focus {
+.c14:focus {
   border: 1px solid #666;
 }
 
-.c15:focus::-webkit-input-placeholder {
+.c14:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c15:focus::-moz-placeholder {
+.c14:focus::-moz-placeholder {
   color: #666;
 }
 
-.c15:focus:-ms-input-placeholder {
+.c14:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c15:focus::placeholder {
+.c14:focus::placeholder {
   color: #666;
 }
 
@@ -585,7 +582,7 @@ exports[`renders correctly with modal open 1`] = `
   flex-direction: column;
 }
 
-.c14 {
+.c13 {
   visibility: border:0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -700,7 +697,7 @@ exports[`renders correctly with modal open 1`] = `
   margin: 1rem 0;
 }
 
-.c12 {
+.c15 {
   width: 100%;
 }
 
@@ -777,7 +774,7 @@ exports[`renders correctly with modal open 1`] = `
 }
 
 @media (min-width:740px) {
-  .c15 {
+  .c14 {
     max-width: 290px;
   }
 }
@@ -869,13 +866,11 @@ exports[`renders correctly with modal open 1`] = `
           onSubmit={[Function]}
         >
           <label
-            aria-label="Email address"
-            className="c11 c12"
+            className="c11"
             htmlFor="email"
-            onChange={[Function]}
           >
             <span
-              className="c13 c14"
+              className="c12 c13"
               color="inherit"
               size="s"
             >
@@ -883,7 +878,7 @@ exports[`renders correctly with modal open 1`] = `
             </span>
             <input
               aria-label="Email address"
-              className="c15 c12"
+              className="c14 c15"
               id="email"
               name="email"
               onChange={[Function]}

--- a/src/components/Molecules/SearchInput/SearchInput.style.js
+++ b/src/components/Molecules/SearchInput/SearchInput.style.js
@@ -28,18 +28,20 @@ const SearchWrapper = styled.div`
 `;
 
 const SearchField = styled(Input)`
-  padding: 13px 0;
-  margin: 0;
-  font-size: ${({ theme }) => theme.fontSize('md')};
-  max-width: 100%;
-  border: 0;
-  outline: ${({ theme }) => theme.color('red')};
-  :focus {
+  input {
+    padding: 13px 0;
+    margin: 0;
+    font-size: ${({ theme }) => theme.fontSize('md')};
+    max-width: 100%;
     border: 0;
-  }
-  ${media('small')} {
-    height: 100px;
-    font-size: ${({ theme }) => theme.fontSize('xxl')};
+    outline: ${({ theme }) => theme.color('red')};
+    :focus {
+      border: 0;
+    }
+    ${media('small')} {
+      height: 100px;
+      font-size: ${({ theme }) => theme.fontSize('xxl')};
+    }
   }
 `;
 

--- a/src/components/Molecules/SearchInput/SearchInput.test.js
+++ b/src/components/Molecules/SearchInput/SearchInput.test.js
@@ -15,7 +15,7 @@ it('renders correctly', () => {
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
-    .c6 {
+    .c5 {
       font-size: 1rem;
       line-height: 1rem;
       text-transform: inherit;
@@ -24,7 +24,7 @@ it('renders correctly', () => {
       font-family: inherit;
     }
 
-    .c8 {
+    .c7 {
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
       font-weight: 400;
       position: relative;
@@ -42,23 +42,23 @@ it('renders correctly', () => {
       color: #000000;
     }
 
-    .c8:focus {
+    .c7:focus {
       border: 1px solid #666;
     }
 
-    .c8:focus::-webkit-input-placeholder {
+    .c7:focus::-webkit-input-placeholder {
       color: #666;
     }
 
-    .c8:focus::-moz-placeholder {
+    .c7:focus::-moz-placeholder {
       color: #666;
     }
 
-    .c8:focus:-ms-input-placeholder {
+    .c7:focus:-ms-input-placeholder {
       color: #666;
     }
 
-    .c8:focus::placeholder {
+    .c7:focus::placeholder {
       color: #666;
     }
 
@@ -72,7 +72,7 @@ it('renders correctly', () => {
       flex-direction: column;
     }
 
-    .c7 {
+    .c6 {
       visibility: border:0;
       -webkit-clip: rect(0 0 0 0);
       clip: rect(0 0 0 0);
@@ -110,7 +110,7 @@ it('renders correctly', () => {
       padding: 0 0.5rem;
     }
 
-    .c5 {
+    .c8 {
       padding: 13px 0;
       margin: 0;
       max-width: 100%;
@@ -118,18 +118,18 @@ it('renders correctly', () => {
       outline: #E52630;
     }
 
-    .c5:focus {
+    .c8:focus {
       border: 0;
     }
 
     @media (min-width:740px) {
-      .c8 {
+      .c7 {
         max-width: 290px;
       }
     }
 
     @media (min-width:740px) {
-      .c5 {
+      .c8 {
         height: 100px;
         font-size: 3rem;
       }
@@ -149,12 +149,11 @@ it('renders correctly', () => {
             className="c3"
           >
             <label
-              className="c4 c5"
+              className="c4"
               htmlFor="search"
-              onChange={[Function]}
             >
               <span
-                className="c6 c7"
+                className="c5 c6"
                 color="inherit"
                 size="s"
               >
@@ -162,7 +161,7 @@ it('renders correctly', () => {
               </span>
               <input
                 aria-describedby="search"
-                className="c8 c5"
+                className="c7 c8"
                 id="search"
                 name="search"
                 onChange={[Function]}

--- a/src/components/Molecules/SearchInput/SearchInput.test.js
+++ b/src/components/Molecules/SearchInput/SearchInput.test.js
@@ -15,7 +15,7 @@ it('renders correctly', () => {
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
-    .c5 {
+    .c6 {
       font-size: 1rem;
       line-height: 1rem;
       text-transform: inherit;
@@ -24,7 +24,7 @@ it('renders correctly', () => {
       font-family: inherit;
     }
 
-    .c7 {
+    .c8 {
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
       font-weight: 400;
       position: relative;
@@ -42,23 +42,23 @@ it('renders correctly', () => {
       color: #000000;
     }
 
-    .c7:focus {
+    .c8:focus {
       border: 1px solid #666;
     }
 
-    .c7:focus::-webkit-input-placeholder {
+    .c8:focus::-webkit-input-placeholder {
       color: #666;
     }
 
-    .c7:focus::-moz-placeholder {
+    .c8:focus::-moz-placeholder {
       color: #666;
     }
 
-    .c7:focus:-ms-input-placeholder {
+    .c8:focus:-ms-input-placeholder {
       color: #666;
     }
 
-    .c7:focus::placeholder {
+    .c8:focus::placeholder {
       color: #666;
     }
 
@@ -72,7 +72,7 @@ it('renders correctly', () => {
       flex-direction: column;
     }
 
-    .c6 {
+    .c7 {
       visibility: border:0;
       -webkit-clip: rect(0 0 0 0);
       clip: rect(0 0 0 0);
@@ -110,7 +110,7 @@ it('renders correctly', () => {
       padding: 0 0.5rem;
     }
 
-    .c8 {
+    .c5 input {
       padding: 13px 0;
       margin: 0;
       max-width: 100%;
@@ -118,18 +118,18 @@ it('renders correctly', () => {
       outline: #E52630;
     }
 
-    .c8:focus {
+    .c5 input:focus {
       border: 0;
     }
 
     @media (min-width:740px) {
-      .c7 {
+      .c8 {
         max-width: 290px;
       }
     }
 
     @media (min-width:740px) {
-      .c8 {
+      .c5 input {
         height: 100px;
         font-size: 3rem;
       }
@@ -149,11 +149,11 @@ it('renders correctly', () => {
             className="c3"
           >
             <label
-              className="c4"
+              className="c4 c5"
               htmlFor="search"
             >
               <span
-                className="c5 c6"
+                className="c6 c7"
                 color="inherit"
                 size="s"
               >
@@ -161,7 +161,7 @@ it('renders correctly', () => {
               </span>
               <input
                 aria-describedby="search"
-                className="c7 c8"
+                className="c8"
                 id="search"
                 name="search"
                 onChange={[Function]}

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -298,7 +298,7 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0.03rem;
 }
 
-.c8 {
+.c7 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -307,7 +307,7 @@ exports[`renders correctly 1`] = `
   font-family: inherit;
 }
 
-.c10 {
+.c9 {
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
   font-weight: 400;
   position: relative;
@@ -325,23 +325,23 @@ exports[`renders correctly 1`] = `
   color: #000000;
 }
 
-.c10:focus {
+.c9:focus {
   border: 1px solid #666;
 }
 
-.c10:focus::-webkit-input-placeholder {
+.c9:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c10:focus::-moz-placeholder {
+.c9:focus::-moz-placeholder {
   color: #666;
 }
 
-.c10:focus:-ms-input-placeholder {
+.c9:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c10:focus::placeholder {
+.c9:focus::placeholder {
   color: #666;
 }
 
@@ -355,7 +355,7 @@ exports[`renders correctly 1`] = `
   flex-direction: column;
 }
 
-.c9 {
+.c8 {
   visibility: border:0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -437,7 +437,7 @@ exports[`renders correctly 1`] = `
   margin: 1rem 0;
 }
 
-.c7 {
+.c10 {
   width: 100%;
 }
 
@@ -464,7 +464,7 @@ exports[`renders correctly 1`] = `
 }
 
 @media (min-width:740px) {
-  .c10 {
+  .c9 {
     max-width: 290px;
   }
 }
@@ -511,13 +511,11 @@ exports[`renders correctly 1`] = `
     onSubmit={[Function]}
   >
     <label
-      aria-label="Email address"
-      className="c6 c7"
+      className="c6"
       htmlFor="email"
-      onChange={[Function]}
     >
       <span
-        className="c8 c9"
+        className="c7 c8"
         color="inherit"
         size="s"
       >
@@ -525,7 +523,7 @@ exports[`renders correctly 1`] = `
       </span>
       <input
         aria-label="Email address"
-        className="c10 c7"
+        className="c9 c10"
         id="email"
         name="email"
         onChange={[Function]}

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -298,7 +298,7 @@ exports[`renders correctly 1`] = `
   letter-spacing: 0.03rem;
 }
 
-.c7 {
+.c8 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -307,7 +307,7 @@ exports[`renders correctly 1`] = `
   font-family: inherit;
 }
 
-.c9 {
+.c10 {
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
   font-weight: 400;
   position: relative;
@@ -325,23 +325,23 @@ exports[`renders correctly 1`] = `
   color: #000000;
 }
 
-.c9:focus {
+.c10:focus {
   border: 1px solid #666;
 }
 
-.c9:focus::-webkit-input-placeholder {
+.c10:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c9:focus::-moz-placeholder {
+.c10:focus::-moz-placeholder {
   color: #666;
 }
 
-.c9:focus:-ms-input-placeholder {
+.c10:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c9:focus::placeholder {
+.c10:focus::placeholder {
   color: #666;
 }
 
@@ -355,7 +355,7 @@ exports[`renders correctly 1`] = `
   flex-direction: column;
 }
 
-.c8 {
+.c9 {
   visibility: border:0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -437,7 +437,7 @@ exports[`renders correctly 1`] = `
   margin: 1rem 0;
 }
 
-.c10 {
+.c7 {
   width: 100%;
 }
 
@@ -464,7 +464,7 @@ exports[`renders correctly 1`] = `
 }
 
 @media (min-width:740px) {
-  .c9 {
+  .c10 {
     max-width: 290px;
   }
 }
@@ -511,11 +511,11 @@ exports[`renders correctly 1`] = `
     onSubmit={[Function]}
   >
     <label
-      className="c6"
+      className="c6 c7"
       htmlFor="email"
     >
       <span
-        className="c7 c8"
+        className="c8 c9"
         color="inherit"
         size="s"
       >
@@ -523,7 +523,7 @@ exports[`renders correctly 1`] = `
       </span>
       <input
         aria-label="Email address"
-        className="c9 c10"
+        className="c10"
         id="email"
         name="email"
         onChange={[Function]}

--- a/src/components/Organisms/Membership/Membership.test.js
+++ b/src/components/Organisms/Membership/Membership.test.js
@@ -48,7 +48,7 @@ it('renders correctly', () => {
       font-family: inherit;
     }
 
-    .c15 {
+    .c16 {
       font-size: 1rem;
       line-height: 1rem;
       text-transform: inherit;
@@ -80,7 +80,7 @@ it('renders correctly', () => {
       object-fit: cover;
     }
 
-    .c16 {
+    .c17 {
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
       font-weight: 400;
       position: relative;
@@ -98,23 +98,23 @@ it('renders correctly', () => {
       color: #000000;
     }
 
-    .c16:focus {
+    .c17:focus {
       border: 1px solid #666;
     }
 
-    .c16:focus::-webkit-input-placeholder {
+    .c17:focus::-webkit-input-placeholder {
       color: #666;
     }
 
-    .c16:focus::-moz-placeholder {
+    .c17:focus::-moz-placeholder {
       color: #666;
     }
 
-    .c16:focus:-ms-input-placeholder {
+    .c17:focus:-ms-input-placeholder {
       color: #666;
     }
 
-    .c16:focus::placeholder {
+    .c17:focus::placeholder {
       color: #666;
     }
 
@@ -299,11 +299,11 @@ it('renders correctly', () => {
       background-color: #961D35;
     }
 
-    .c17 {
+    .c15 {
       display: block;
     }
 
-    .c17 input {
+    .c15 input {
       border: 2px solid #E1E2E3;
       font-size: 1.5rem;
       font-weight: 800;
@@ -331,7 +331,7 @@ it('renders correctly', () => {
     }
 
     @media (min-width:740px) {
-      .c16 {
+      .c17 {
         max-width: 290px;
       }
     }
@@ -462,11 +462,11 @@ it('renders correctly', () => {
                 className="c13"
               >
                 <label
-                  className="c14"
+                  className="c14 c15"
                   htmlFor="mship-1--moneyBuy-box1"
                 >
                   <span
-                    className="c15 "
+                    className="c16 "
                     color="inherit"
                     size="s"
                   >
@@ -475,7 +475,7 @@ it('renders correctly', () => {
                   <input
                     aria-describedby="mship-1--moneyBuy-box1"
                     aria-label="£5"
-                    className="c16 c17"
+                    className="c17"
                     id="mship-1--moneyBuy-box1"
                     name="mship-1--moneyBuy1"
                     onClick={[Function]}
@@ -486,11 +486,11 @@ it('renders correctly', () => {
                   
                 </label>
                 <label
-                  className="c14"
+                  className="c14 c18"
                   htmlFor="mship-1--moneyBuy-box2"
                 >
                   <span
-                    className="c15 "
+                    className="c16 "
                     color="inherit"
                     size="s"
                   >
@@ -499,7 +499,7 @@ it('renders correctly', () => {
                   <input
                     aria-describedby="mship-1--moneyBuy-box2"
                     aria-label="£10"
-                    className="c16 c18"
+                    className="c17"
                     id="mship-1--moneyBuy-box2"
                     name="mship-1--moneyBuy2"
                     onClick={[Function]}
@@ -510,11 +510,11 @@ it('renders correctly', () => {
                   
                 </label>
                 <label
-                  className="c14"
+                  className="c14 c15"
                   htmlFor="mship-1--moneyBuy-box3"
                 >
                   <span
-                    className="c15 "
+                    className="c16 "
                     color="inherit"
                     size="s"
                   >
@@ -523,7 +523,7 @@ it('renders correctly', () => {
                   <input
                     aria-describedby="mship-1--moneyBuy-box3"
                     aria-label="£20"
-                    className="c16 c17"
+                    className="c17"
                     id="mship-1--moneyBuy-box3"
                     name="mship-1--moneyBuy3"
                     onClick={[Function]}
@@ -545,11 +545,11 @@ it('renders correctly', () => {
                   Other amount
                 </span>
                 <label
-                  className="c14"
+                  className="c14 c22"
                   htmlFor="mship-1--MoneyBuy-userInput"
                 >
                   <span
-                    className="c15 "
+                    className="c16 "
                     color="inherit"
                     size="s"
                   >
@@ -558,7 +558,7 @@ it('renders correctly', () => {
                   <input
                     aria-describedby="mship-1--MoneyBuy-userInput"
                     aria-label="Input a different amount"
-                    className="c16 c22"
+                    className="c17"
                     id="mship-1--MoneyBuy-userInput"
                     max="5000"
                     min="1"

--- a/src/components/Organisms/Membership/Membership.test.js
+++ b/src/components/Organisms/Membership/Membership.test.js
@@ -48,7 +48,7 @@ it('renders correctly', () => {
       font-family: inherit;
     }
 
-    .c16 {
+    .c15 {
       font-size: 1rem;
       line-height: 1rem;
       text-transform: inherit;
@@ -80,7 +80,7 @@ it('renders correctly', () => {
       object-fit: cover;
     }
 
-    .c17 {
+    .c16 {
       font-family: 'Montserrat',Helvetica,Arial,sans-serif;
       font-weight: 400;
       position: relative;
@@ -98,23 +98,23 @@ it('renders correctly', () => {
       color: #000000;
     }
 
-    .c17:focus {
+    .c16:focus {
       border: 1px solid #666;
     }
 
-    .c17:focus::-webkit-input-placeholder {
+    .c16:focus::-webkit-input-placeholder {
       color: #666;
     }
 
-    .c17:focus::-moz-placeholder {
+    .c16:focus::-moz-placeholder {
       color: #666;
     }
 
-    .c17:focus:-ms-input-placeholder {
+    .c16:focus:-ms-input-placeholder {
       color: #666;
     }
 
-    .c17:focus::placeholder {
+    .c16:focus::placeholder {
       color: #666;
     }
 
@@ -299,11 +299,11 @@ it('renders correctly', () => {
       background-color: #961D35;
     }
 
-    .c15 {
+    .c17 {
       display: block;
     }
 
-    .c15 input {
+    .c17 input {
       border: 2px solid #E1E2E3;
       font-size: 1.5rem;
       font-weight: 800;
@@ -331,7 +331,7 @@ it('renders correctly', () => {
     }
 
     @media (min-width:740px) {
-      .c17 {
+      .c16 {
         max-width: 290px;
       }
     }
@@ -462,13 +462,11 @@ it('renders correctly', () => {
                 className="c13"
               >
                 <label
-                  aria-label="£5"
-                  className="c14 c15"
+                  className="c14"
                   htmlFor="mship-1--moneyBuy-box1"
-                  onClick={[Function]}
                 >
                   <span
-                    className="c16 "
+                    className="c15 "
                     color="inherit"
                     size="s"
                   >
@@ -477,7 +475,7 @@ it('renders correctly', () => {
                   <input
                     aria-describedby="mship-1--moneyBuy-box1"
                     aria-label="£5"
-                    className="c17 c15"
+                    className="c16 c17"
                     id="mship-1--moneyBuy-box1"
                     name="mship-1--moneyBuy1"
                     onClick={[Function]}
@@ -488,13 +486,11 @@ it('renders correctly', () => {
                   
                 </label>
                 <label
-                  aria-label="£10"
-                  className="c14 c18"
+                  className="c14"
                   htmlFor="mship-1--moneyBuy-box2"
-                  onClick={[Function]}
                 >
                   <span
-                    className="c16 "
+                    className="c15 "
                     color="inherit"
                     size="s"
                   >
@@ -503,7 +499,7 @@ it('renders correctly', () => {
                   <input
                     aria-describedby="mship-1--moneyBuy-box2"
                     aria-label="£10"
-                    className="c17 c18"
+                    className="c16 c18"
                     id="mship-1--moneyBuy-box2"
                     name="mship-1--moneyBuy2"
                     onClick={[Function]}
@@ -514,13 +510,11 @@ it('renders correctly', () => {
                   
                 </label>
                 <label
-                  aria-label="£20"
-                  className="c14 c15"
+                  className="c14"
                   htmlFor="mship-1--moneyBuy-box3"
-                  onClick={[Function]}
                 >
                   <span
-                    className="c16 "
+                    className="c15 "
                     color="inherit"
                     size="s"
                   >
@@ -529,7 +523,7 @@ it('renders correctly', () => {
                   <input
                     aria-describedby="mship-1--moneyBuy-box3"
                     aria-label="£20"
-                    className="c17 c15"
+                    className="c16 c17"
                     id="mship-1--moneyBuy-box3"
                     name="mship-1--moneyBuy3"
                     onClick={[Function]}
@@ -551,19 +545,11 @@ it('renders correctly', () => {
                   Other amount
                 </span>
                 <label
-                  aria-label="Input a different amount"
-                  className="c14 c22"
+                  className="c14"
                   htmlFor="mship-1--MoneyBuy-userInput"
-                  max="5000"
-                  min="1"
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  pattern="[^[0-9]+([,.][0-9]+)?$]"
-                  step="0.01"
                 >
                   <span
-                    className="c16 "
+                    className="c15 "
                     color="inherit"
                     size="s"
                   >
@@ -572,7 +558,7 @@ it('renders correctly', () => {
                   <input
                     aria-describedby="mship-1--MoneyBuy-userInput"
                     aria-label="Input a different amount"
-                    className="c17 c22"
+                    className="c16 c22"
                     id="mship-1--MoneyBuy-userInput"
                     max="5000"
                     min="1"


### PR DESCRIPTION
Fixes #290 

Type: patch

## Changes proposed in this PR

- Alters the Input component so that props captured by `...rest` (including event handlers) are only added to the InputField element
- Adds className prop to Input and passes this to the outer element, Label, only (previously className was being added to both elements) 