### PR TITLE
Feature/error text atom

### DIFF
--- a/src/components/Atoms/ErrorText/ErrorText.js
+++ b/src/components/Atoms/ErrorText/ErrorText.js
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+import Text from '../Text/Text';
+import spacing from '../../../theme/shared/spacing';
+import alertIcon from '../Input/assets/error-alert-icon.png';
+
+const ErrorText = styled(Text)`
+  display: inline-block;
+  color: ${({ theme }) => theme.color('red')};
+  font-weight: ${({ weight }) => weight};
+  margin-top: ${spacing('sm')};
+  :before {
+    position: relative;
+    content: '';
+    top: 2px;
+    margin-right: 6px;
+    background: url(${alertIcon}) left 0/100% no-repeat;
+    width: 18px;
+    height: 19px;
+    display: inline-block;
+    vertical-align: top;
+    color: ${({ theme }) => theme.color('red')};
+  }
+`;
+
+export default ErrorText;

--- a/src/components/Atoms/ErrorText/ErrorText.md
+++ b/src/components/Atoms/ErrorText/ErrorText.md
@@ -1,0 +1,5 @@
+# ErrorText
+
+```jsx
+<ErrorText size="sm">This is an error</ErrorText>
+```

--- a/src/components/Atoms/ErrorText/ErrorText.test.js
+++ b/src/components/Atoms/ErrorText/ErrorText.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import 'jest-styled-components';
+
+import renderWithTheme from '../../../hoc/shallowWithTheme';
+import ErrorText from './ErrorText';
+
+it('renders correctly', () => {
+  const renderer = renderWithTheme(
+    <ErrorText size="sm">This is an error</ErrorText>
+  );
+  expect(renderer.toJSON()).toMatchSnapshot();
+});

--- a/src/components/Atoms/ErrorText/__snapshots__/ErrorText.test.js.snap
+++ b/src/components/Atoms/ErrorText/__snapshots__/ErrorText.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+.c0 {
+  text-transform: inherit;
+  line-height: normal;
+  font-family: inherit;
+}
+
+.c1 {
+  display: inline-block;
+  color: #E52630;
+  margin-top: 0.5rem;
+}
+
+.c1:before {
+  position: relative;
+  content: '';
+  top: 2px;
+  margin-right: 6px;
+  background: url(mock.asset) left 0/100% no-repeat;
+  width: 18px;
+  height: 19px;
+  display: inline-block;
+  vertical-align: top;
+  color: #E52630;
+}
+
+<span
+  className="c0 c1"
+  color="inherit"
+  size="sm"
+>
+  This is an error
+</span>
+`;

--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import Text from '../Text/Text';
-import alertIcon from './assets/error-alert-icon.png';
+import ErrorText from '../ErrorText/ErrorText';
 import hideVisually from '../../../theme/shared/hideVisually';
 import spacing from '../../../theme/shared/spacing';
 
@@ -49,28 +49,6 @@ const Label = styled.label`
   flex-direction: column;
   font-weight: bold;
   color: ${({ theme }) => theme.color('grey')};
-`;
-
-/**
- * Text error component
- */
-const ErrorText = styled(Text)`
-  display: inline-block;
-  color: red;
-  font-weight: ${({ weight }) => weight};
-  margin-top: ${spacing('sm')};
-  :before {
-    position: relative;
-    content: '';
-    top: 2px;
-    margin-right: 6px;
-    background: url(${alertIcon}) left 0/100% no-repeat;
-    width: 18px;
-    height: 19px;
-    display: inline-block;
-    vertical-align: top;
-    color: ${({ theme }) => theme.color('red')};
-  }
 `;
 
 /**

--- a/src/components/Atoms/Select/Select.js
+++ b/src/components/Atoms/Select/Select.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import Text from '../Text/Text';
+import ErrorText from '../ErrorText/ErrorText';
 import hideVisually from '../../../theme/shared/hideVisually';
 import dropDownIcon from './assets/drop-down-dark-purple.svg';
-import alertIcon from './assets/error-alert-icon.png';
 import spacing from '../../../theme/shared/spacing';
 
 const StyledSelect = styled.select`
@@ -48,30 +48,6 @@ const Label = styled.label`
 
 const LabelText = styled(Text)`
   ${({ hideLabel }) => hideLabel && hideVisually}
-`;
-
-/**
- * Text error component
- */
-const ErrorText = styled(Text)`
-  display: inline-block;
-  color: ${({ theme }) => theme.color('red')};
-  font-weight: ${({ weight }) => weight};
-  margin-top: ${({ theme }) => theme.fontSize('xxs')};
-  :before {
-    position: relative;
-    content: '';
-    display: inline-block;
-    top: 2px;
-    vertical-align: middle;
-    margin-right: 6px;
-    background: url(${alertIcon}) left 0/100% no-repeat;
-    width: 18px;
-    height: 19px;
-    display: inline-block;
-    vertical-align: top;
-    color: ${({ theme }) => theme.color('red')};
-  }
 `;
 
 const Select = ({

--- a/src/components/Atoms/TextArea/TextArea.js
+++ b/src/components/Atoms/TextArea/TextArea.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import Text from '../Text/Text';
-import alertIcon from './assets/error-alert-icon.png';
+import ErrorText from '../ErrorText/ErrorText';
 
 /**
  * Textarea component
@@ -70,28 +70,6 @@ const Label = styled.label.attrs(({ id }) => ({
 }))`
   display: flex;
   flex-direction: column;
-`;
-
-/**
- * Text error component
- */
-const ErrorText = styled(Text)`
-  color: red;
-  font-weight: ${({ weight }) => weight};
-  :before {
-    position: relative;
-    content: '';
-    display: inline-block;
-    top: 2px;
-    vertical-align: middle;
-    margin-right: 6px;
-    background: url(${alertIcon}) left 0/100% no-repeat;
-    width: 18px;
-    height: 19px;
-    display: inline-block;
-    vertical-align: top;
-    color: ${({ theme }) => theme.color('red')};
-  }
 `;
 
 const TextArea = ({ id, label, errorMsg, ...rest }) => {

--- a/src/components/Molecules/HeaderEsuWithIcon/__snapshots__/HeaderEsuWithIcon.test.js.snap
+++ b/src/components/Molecules/HeaderEsuWithIcon/__snapshots__/HeaderEsuWithIcon.test.js.snap
@@ -28,6 +28,25 @@ exports[`renders correctly with error message 1`] = `
   font-family: inherit;
 }
 
+.c17 {
+  display: inline-block;
+  color: #E52630;
+  margin-top: 0.5rem;
+}
+
+.c17:before {
+  position: relative;
+  content: '';
+  top: 2px;
+  margin-right: 6px;
+  background: url(mock.asset) left 0/100% no-repeat;
+  width: 18px;
+  height: 19px;
+  display: inline-block;
+  vertical-align: top;
+  color: #E52630;
+}
+
 .c15 {
   font-weight: normal;
   position: relative;
@@ -78,25 +97,6 @@ exports[`renders correctly with error message 1`] = `
   flex-direction: column;
   font-weight: bold;
   color: #969598;
-}
-
-.c17 {
-  display: inline-block;
-  color: red;
-  margin-top: 0.5rem;
-}
-
-.c17:before {
-  position: relative;
-  content: '';
-  top: 2px;
-  margin-right: 6px;
-  background: url(mock.asset) left 0/100% no-repeat;
-  width: 18px;
-  height: 19px;
-  display: inline-block;
-  vertical-align: top;
-  color: #E52630;
 }
 
 .c14 {

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ export {
 export {
   default as TextInputWithDropdown
 } from './components/Atoms/TextInputWithDropdown/TextInputWithDropdown';
+export { default as ErrorText } from './components/Atoms/ErrorText/ErrorText';
 
 /* Molecules */
 


### PR DESCRIPTION
Extracts the ErrorText component into its own atom so that:

(a) We don't have three different copy-pasted versions in Input, Select, and TextArea (one of which had the wrong shade of red)

(b) It can be used independently of the input fields in other projects

Wondering if it needs some design tweaking? Is there a new design for this in the new design system?