### PR TITLE
feat: Forwarding refs on input components

### DIFF
--- a/src/components/Atoms/Button/Button.js
+++ b/src/components/Atoms/Button/Button.js
@@ -35,16 +35,11 @@ const StyledButton = styled.button`
   }
 `;
 
-const Button = ({ children, wrapper, ...rest }) => {
-  if (wrapper) {
-    return (
-      <StyledButton as="span" {...rest}>
-        {children}
-      </StyledButton>
-    );
-  }
-  return <StyledButton {...rest}>{children}</StyledButton>;
-};
+const Button = React.forwardRef(({ children, wrapper, ...rest }, ref) => (
+  <StyledButton {...rest} as={wrapper ? 'span' : 'button'} ref={ref}>
+    {children}
+  </StyledButton>
+));
 
 Button.propTypes = {
   /** Buttons as span */

--- a/src/components/Atoms/Checkbox/Checkbox.js
+++ b/src/components/Atoms/Checkbox/Checkbox.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import Text from '../Text/Text';
 import checkBoxIcon from './assets/checkbox-white-tick.png';
 
-const StyledInput = styled.input`
+const StyledCheckboxInput = styled.input`
   font-size: ${({ theme }) => theme.fontSize('sm')};
   display: block;
   box-sizing: border-box;
@@ -45,15 +45,13 @@ const Label = styled.label`
   margin-bottom: 8px;
 `;
 
-const Checkbox = ({ label, value, ...rest }) => {
-  return (
-    <Label>
-      <StyledInput type="checkbox" {...rest} value={value} />
-      <span />
-      <Text weight="bold">{label}</Text>
-    </Label>
-  );
-};
+const Checkbox = React.forwardRef(({ label, value, ...rest }, ref) => (
+  <Label>
+    <StyledCheckboxInput type="checkbox" {...rest} value={value} ref={ref} />
+    <span />
+    <Text weight="bold">{label}</Text>
+  </Label>
+));
 
 Checkbox.propTypes = {
   name: PropTypes.string.isRequired,

--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -58,20 +58,21 @@ const TextLabel = styled(Text)`
   visibility: ${({ showLabel }) => !showLabel && hideVisually};
 `;
 
-const Input = ({
-  errorMsg,
-  id,
-  label,
-  showLabel,
-  type,
-  hasAria,
-  className,
-  labelProps,
-  ...rest
-}) => {
-  const error = errorMsg && errorMsg.length > 0;
-
-  return (
+const Input = React.forwardRef(
+  (
+    {
+      errorMsg,
+      id,
+      label,
+      showLabel,
+      type,
+      hasAria,
+      className,
+      labelProps,
+      ...rest
+    },
+    ref
+  ) => (
     <Label htmlFor={id} className={className} {...labelProps}>
       <TextLabel showLabel={showLabel} weight="bold">
         {label}
@@ -80,17 +81,18 @@ const Input = ({
         id={id}
         type={type}
         {...rest}
-        error={error ? 1 : 0}
+        error={!!errorMsg}
         aria-describedby={hasAria ? id : undefined}
+        ref={ref}
       />
-      {error && (
+      {errorMsg && (
         <ErrorText size="sm" data-test="error-message">
           {errorMsg}
         </ErrorText>
       )}
     </Label>
-  );
-};
+  )
+);
 
 Input.propTypes = {
   name: PropTypes.string.isRequired,

--- a/src/components/Atoms/RadioButton/RadioButton.js
+++ b/src/components/Atoms/RadioButton/RadioButton.js
@@ -7,7 +7,7 @@ import Text from '../Text/Text';
 /**
  * Input radio component
  */
-const StyledInput = styled.input`
+const StyledRadioInput = styled.input`
   background-color: ${({ color, theme }) =>
     color ? theme.color(color) : theme.color('white')};
   font-size: ${({ theme }) => theme.fontSize('sm')};
@@ -58,21 +58,20 @@ const Label = styled.label`
   position: relative;
 `;
 
-const RadioButton = ({ label, name, value, ...rest }) => {
-  return (
-    <Label htmlFor={value}>
-      <StyledInput
-        type="radio"
-        {...rest}
-        name={name}
-        value={value}
-        id={value}
-      />
-      <span />
-      <Text weight="bold">{label}</Text>
-    </Label>
-  );
-};
+const RadioButton = React.forwardRef(({ label, name, value, ...rest }, ref) => (
+  <Label htmlFor={value}>
+    <StyledRadioInput
+      type="radio"
+      {...rest}
+      name={name}
+      value={value}
+      id={value}
+      ref={ref}
+    />
+    <span />
+    <Text weight="bold">{label}</Text>
+  </Label>
+));
 
 RadioButton.propTypes = {
   name: PropTypes.string.isRequired,

--- a/src/components/Atoms/Select/Select.js
+++ b/src/components/Atoms/Select/Select.js
@@ -51,50 +51,56 @@ const LabelText = styled(Text)`
   ${({ hideLabel }) => hideLabel && hideVisually}
 `;
 
-const Select = ({
-  errorMsg,
-  description,
-  label,
-  options,
-  hideLabel,
-  defaultValue,
-  onChange,
-  greyDescription,
-  ...rest
-}) => {
-  const [value, setValue] = useState('');
+const Select = React.forwardRef(
+  (
+    {
+      errorMsg,
+      description,
+      label,
+      options,
+      hideLabel,
+      defaultValue,
+      onChange,
+      greyDescription,
+      ...rest
+    },
+    ref
+  ) => {
+    const [value, setValue] = useState('');
 
-  return (
-    <Label>
-      <LabelText hideLabel={hideLabel} weight="bold">
-        {label}
-      </LabelText>
-      <StyledSelect
-        onChange={e => {
-          setValue(e.currentTarget.value);
-          if (onChange) {
-            onChange(e);
-          }
-        }}
-        {...rest}
-        error={errorMsg}
-        defaultValue={defaultValue}
-        hasValue={!!value}
-        greyDescription={greyDescription}
-      >
-        <option disabled value="">
-          {description}
-        </option>
-        {options.map(option => (
-          <option key={option.value} value={option.value}>
-            {option.displayValue}
+    return (
+      <Label>
+        <LabelText hideLabel={hideLabel} weight="bold">
+          {label}
+        </LabelText>
+        <StyledSelect
+          onChange={e => {
+            setValue(e.currentTarget.value);
+            if (onChange) {
+              onChange(e);
+            }
+          }}
+          {...rest}
+          error={errorMsg}
+          defaultValue={defaultValue}
+          hasValue={!!value}
+          greyDescription={greyDescription}
+          ref={ref}
+        >
+          <option disabled value="">
+            {description}
           </option>
-        ))}
-      </StyledSelect>
-      {errorMsg && <ErrorText size="sm">{errorMsg}</ErrorText>}
-    </Label>
-  );
-};
+          {options.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.displayValue}
+            </option>
+          ))}
+        </StyledSelect>
+        {errorMsg && <ErrorText size="sm">{errorMsg}</ErrorText>}
+      </Label>
+    );
+  }
+);
 
 Select.propTypes = {
   label: PropTypes.string.isRequired,

--- a/src/components/Atoms/TextArea/TextArea.js
+++ b/src/components/Atoms/TextArea/TextArea.js
@@ -8,7 +8,7 @@ import ErrorText from '../ErrorText/ErrorText';
 /**
  * Textarea component
  */
-const StyledInput = styled.textarea`
+const StyledTextArea = styled.textarea`
   box-sizing: border-box;
   width: 100%;
   margin: 10px 0;
@@ -72,16 +72,18 @@ const Label = styled.label.attrs(({ id }) => ({
   flex-direction: column;
 `;
 
-const TextArea = ({ id, label, errorMsg, ...rest }) => {
-  const error = errorMsg && errorMsg.length > 0;
-  return (
-    <Label>
-      <Text weight="bold">{label}</Text>
-      <StyledInput {...rest} error={error ? 1 : 0} aria-describedby={id} />
-      {error && <ErrorText size="sm">{errorMsg}</ErrorText>}
-    </Label>
-  );
-};
+const TextArea = React.forwardRef(({ id, label, errorMsg, ...rest }, ref) => (
+  <Label>
+    <Text weight="bold">{label}</Text>
+    <StyledTextArea
+      {...rest}
+      error={!!errorMsg}
+      aria-describedby={id}
+      ref={ref}
+    />
+    {errorMsg && <ErrorText size="sm">{errorMsg}</ErrorText>}
+  </Label>
+));
 
 TextArea.propTypes = {
   name: PropTypes.string.isRequired,


### PR DESCRIPTION
It can be useful / necessary to attach refs to form inputs to access their state / values

Therefore it's probably best if any component library forwards refs on form inputs

Additionally, we have started using `react-hook-form` which heavily encourages you to use `uncontrolled` inputs (I think mostly for performance reasons). To do so, we need to forward refs to the underlying inputs.

Once we have done this, we should be able to simplify the `MarketingPreferences` component and the new fundraise form a bit (e.g. we won't need to use the `Controller` component)