### PR TITLE
Fix/313 school lookup accessiblity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,10 @@ jobs:
     docker:
 
       # See https://github.com/cypress-io/cypress-docker-images
-      - image: cypress/browsers:node13.8.0-chrome81-ff75
+      - image: cypress/browsers:node12.18.0-chrome83-ff77
         environment:
           TERM: xterm
+          NODE_OPTIONS: --max_old_space_size=4096
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
       - run:
           name: Run unit tests
-          command: yarn test --max_old_space_size=4096
+          command: yarn test --max_old_space_size=4096 --maxWorkers=2
 
       - run:
           name: Release to npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - image: cypress/browsers:node12.18.0-chrome83-ff77
         environment:
           TERM: xterm
+          NODE_OPTIONS: --max_old_space_size=4096
 
     working_directory: ~/repo
 
@@ -36,7 +37,7 @@ jobs:
 
       - run:
           name: Run unit tests
-          command: yarn test --max_old_space_size=4096 --maxWorkers=2
+          command: yarn test --maxWorkers=2
 
       - run:
           name: Release to npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
       - image: cypress/browsers:node12.18.0-chrome83-ff77
         environment:
           TERM: xterm
-          NODE_OPTIONS: --max_old_space_size=4096
 
     working_directory: ~/repo
 
@@ -37,7 +36,7 @@ jobs:
 
       - run:
           name: Run unit tests
-          command: yarn test
+          command: yarn test --max_old_space_size=4096
 
       - run:
           name: Release to npm

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -138,7 +138,7 @@ const Options = ({
   };
 
   return (
-    <Dropdown {...rest} tabIndex="0">
+    <Dropdown {...rest}>
       <DropdownList
         role="listbox"
         onBlur={onBlur}

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import Text from '../Text/Text';
@@ -123,12 +123,10 @@ const Options = ({
   activeOption,
   ...rest
 }) => {
+  // todo: aria-activedescendant
   return (
-    <Dropdown {...rest}>
-      <DropdownList
-        role="listbox"
-        aria-activedescendant={`option-${activeOption}`}
-      >
+    <Dropdown {...rest} tabIndex="0">
+      <DropdownList role="listbox">
         {dropdownInstruction && (
           <DropdownItem role="option">
             <TextItalic>{dropdownInstruction}</TextItalic>
@@ -149,7 +147,7 @@ const Options = ({
             tabIndex="-1"
             aria-selected={index === activeOption}
             ref={element =>
-              element && index === activeOption && element.focus()
+              index === activeOption && element && element.focus()
             }
           >
             <Text>{option}</Text>

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import Text from '../Text/Text';

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -21,45 +21,51 @@ import makeOnEnterHandler from '../../../utils/makeOnEnterHandler';
  *
  * See the Typeahead and SchoolLookup molecules for the full implementation
  */
-const TextInputWithDropdown = ({
-  value,
-  options,
-  onChange,
-  onSelect,
-  id,
-  name,
-  label,
-  dropdownInstruction,
-  className,
-  ...otherInputProps
-}) => {
-  const inputProps = {
-    value,
-    onChange,
-    id,
-    name,
-    label,
-    autoComplete: 'off',
-    type: 'text',
-    ...otherInputProps
-  };
+const TextInputWithDropdown = React.forwardRef(
+  (
+    {
+      value,
+      options,
+      onChange,
+      onSelect,
+      id,
+      name,
+      label,
+      dropdownInstruction,
+      className,
+      ...otherInputProps
+    },
+    ref
+  ) => {
+    const inputProps = {
+      value,
+      onChange,
+      id,
+      name,
+      label,
+      autoComplete: 'off',
+      type: 'text',
+      ...otherInputProps
+    };
 
-  const optionsProps = {
-    options,
-    onSelect,
-    dropdownInstruction
-  };
+    const optionsProps = {
+      options,
+      onSelect,
+      dropdownInstruction
+    };
 
-  return (
-    <Container className={`TextInputWithDropdown ${className}`.trim()}>
-      <InputWithSpaceAfterLabel
-        {...inputProps}
-        className="TextInputWithDropdown__input"
-      />
-      <Options {...optionsProps} className="TextInputWithDropdown__options" />
-    </Container>
-  );
-};
+    return (
+      <Container className={`TextInputWithDropdown ${className}`.trim()}>
+        <InputWithSpaceAfterLabel
+          {...inputProps}
+          className="TextInputWithDropdown__input"
+          ref={ref}
+        />
+        <Options {...optionsProps} className="TextInputWithDropdown__options" />
+      </Container>
+    );
+  }
+);
 
 const Options = ({ options, dropdownInstruction, onSelect, ...rest }) => {
   if (options.length === 0) {

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
+import Input from '../Input/Input';
 import Text from '../Text/Text';
 import {
   Container,
@@ -8,8 +9,7 @@ import {
   DropdownList,
   DropdownItem,
   DropdownItemSelectable,
-  TextItalic,
-  InputWithSpaceAfterLabel
+  TextItalic
 } from './TextInputWithDropdown.style';
 
 const KEY_CODE_ENTER = 13;
@@ -21,8 +21,8 @@ const KEY_CODE_ESCAPE = 27;
 /**
  * This component deals with the visual aspect of a text input with typeahead-style functionality
  *
- * Proper functionality / behaviour (e.g. API querying, state management, etc.) are handled by the parent
- *  component (via the value, options, onChange and onSelect props)
+ * API querying and state management (aside from that related to keyboard usage/accessibility) are
+ *  handled by the parent component (via the value, options, onChange and onSelect props)
  *
  * See the Typeahead and SchoolLookup molecules for the full implementation
  */
@@ -101,7 +101,7 @@ const TextInputWithDropdown = React.forwardRef(
         className={`TextInputWithDropdown ${className}`.trim()}
         onKeyDown={navigateOptions}
       >
-        <InputWithSpaceAfterLabel
+        <Input
           {...inputProps}
           className="TextInputWithDropdown__input"
           ref={ref}

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -92,7 +92,8 @@ const TextInputWithDropdown = React.forwardRef(
       options,
       onSelect,
       dropdownInstruction,
-      activeOption
+      activeOption,
+      resetActiveOption: () => setActiveOption(-1)
     };
 
     return (
@@ -121,12 +122,30 @@ const Options = ({
   dropdownInstruction,
   onSelect,
   activeOption,
+  resetActiveOption,
   ...rest
 }) => {
-  // todo: aria-activedescendant
+  // Reset 'activeOption' when the list is unfocused.
+  const onBlur = e => {
+    const { target } = e;
+    // There's a delay before the new activeOption becomes the document.activeElement when
+    //  scrolling through the dropdown list via keyboard.
+    setTimeout(() => {
+      if (document.activeElement.parentNode !== target.parentNode) {
+        resetActiveOption();
+      }
+    }, 100);
+  };
+
   return (
     <Dropdown {...rest} tabIndex="0">
-      <DropdownList role="listbox">
+      <DropdownList
+        role="listbox"
+        onBlur={onBlur}
+        aria-activedescendant={
+          activeOption > -1 ? `option-${activeOption}` : undefined
+        }
+      >
         {dropdownInstruction && (
           <DropdownItem role="option">
             <TextItalic>{dropdownInstruction}</TextItalic>
@@ -146,8 +165,10 @@ const Options = ({
             }}
             tabIndex="-1"
             aria-selected={index === activeOption}
-            ref={element =>
-              index === activeOption && element && element.focus()
+            ref={
+              index === activeOption
+                ? element => element && element.focus()
+                : null
             }
           >
             <Text>{option}</Text>
@@ -179,7 +200,8 @@ Options.propTypes = {
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
   onSelect: PropTypes.func.isRequired,
   dropdownInstruction: PropTypes.string,
-  activeOption: PropTypes.number.isRequired
+  activeOption: PropTypes.number.isRequired,
+  resetActiveOption: PropTypes.func.isRequired
 };
 
 Options.defaultProps = {

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
@@ -4,7 +4,6 @@ import spacing from '../../../theme/shared/spacing';
 import zIndex from '../../../theme/shared/zIndex';
 import { screen } from '../../../theme/shared/size';
 import Text from '../Text/Text';
-import Input from '../Input/Input';
 
 const Container = styled.div`
   position: relative;

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
@@ -51,18 +51,11 @@ const TextItalic = styled(Text)`
   font-style: italic;
 `;
 
-const InputWithSpaceAfterLabel = styled(Input)`
-  input {
-    margin-top: ${spacing('sm')};
-  }
-`;
-
 export {
   Container,
   Dropdown,
   DropdownList,
   DropdownItem,
   DropdownItemSelectable,
-  TextItalic,
-  InputWithSpaceAfterLabel
+  TextItalic
 };

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
@@ -41,7 +41,8 @@ const DropdownItemSelectable = styled(DropdownItem)`
   cursor: pointer;
   border-top: 1px solid ${({ theme }) => theme.color('grey_light')};
 
-  &:hover {
+  &:hover,
+  &:focus {
     background-color: ${({ theme }) => theme.color('grey_light')};
   }
 `;

--- a/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
+++ b/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly with no value and no options 1`] = `
-.c3 {
+.c2 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -10,7 +10,7 @@ exports[`renders correctly with no value and no options 1`] = `
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
-.c4 {
+.c3 {
   font-weight: normal;
   position: relative;
   box-sizing: border-box;
@@ -30,23 +30,23 @@ exports[`renders correctly with no value and no options 1`] = `
   margin-top: 0.5rem;
 }
 
-.c4:focus {
+.c3:focus {
   border: 1px solid #666;
 }
 
-.c4:focus::-webkit-input-placeholder {
+.c3:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c4:focus::-moz-placeholder {
+.c3:focus::-moz-placeholder {
   color: #666;
 }
 
-.c4:focus:-ms-input-placeholder {
+.c3:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c4:focus::placeholder {
+.c3:focus::placeholder {
   color: #666;
 }
 
@@ -66,25 +66,22 @@ exports[`renders correctly with no value and no options 1`] = `
   position: relative;
 }
 
-.c2 input {
-  margin-top: 0.5rem;
-}
-
 @media (min-width:740px) {
-  .c4 {
+  .c3 {
     max-width: 290px;
   }
 }
 
 <div
   className="c0 TextInputWithDropdown"
+  onKeyDown={[Function]}
 >
   <label
-    className="c1 c2 TextInputWithDropdown__input"
+    className="c1 TextInputWithDropdown__input"
     htmlFor="text-input-with-dropdown"
   >
     <span
-      className="c3 "
+      className="c2 "
       color="inherit"
       size="s"
     >
@@ -93,7 +90,7 @@ exports[`renders correctly with no value and no options 1`] = `
     <input
       aria-describedby="text-input-with-dropdown"
       autoComplete="off"
-      className="c4"
+      className="c3"
       id="text-input-with-dropdown"
       name="query"
       onChange={[Function]}
@@ -107,7 +104,7 @@ exports[`renders correctly with no value and no options 1`] = `
 `;
 
 exports[`renders correctly with value and no options 1`] = `
-.c3 {
+.c2 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -116,7 +113,7 @@ exports[`renders correctly with value and no options 1`] = `
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
-.c4 {
+.c3 {
   font-weight: normal;
   position: relative;
   box-sizing: border-box;
@@ -136,23 +133,23 @@ exports[`renders correctly with value and no options 1`] = `
   margin-top: 0.5rem;
 }
 
-.c4:focus {
+.c3:focus {
   border: 1px solid #666;
 }
 
-.c4:focus::-webkit-input-placeholder {
+.c3:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c4:focus::-moz-placeholder {
+.c3:focus::-moz-placeholder {
   color: #666;
 }
 
-.c4:focus:-ms-input-placeholder {
+.c3:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c4:focus::placeholder {
+.c3:focus::placeholder {
   color: #666;
 }
 
@@ -172,25 +169,22 @@ exports[`renders correctly with value and no options 1`] = `
   position: relative;
 }
 
-.c2 input {
-  margin-top: 0.5rem;
-}
-
 @media (min-width:740px) {
-  .c4 {
+  .c3 {
     max-width: 290px;
   }
 }
 
 <div
   className="c0 TextInputWithDropdown"
+  onKeyDown={[Function]}
 >
   <label
-    className="c1 c2 TextInputWithDropdown__input"
+    className="c1 TextInputWithDropdown__input"
     htmlFor="text-input-with-dropdown"
   >
     <span
-      className="c3 "
+      className="c2 "
       color="inherit"
       size="s"
     >
@@ -199,7 +193,7 @@ exports[`renders correctly with value and no options 1`] = `
     <input
       aria-describedby="text-input-with-dropdown"
       autoComplete="off"
-      className="c4"
+      className="c3"
       id="text-input-with-dropdown"
       name="query"
       onChange={[Function]}
@@ -213,7 +207,7 @@ exports[`renders correctly with value and no options 1`] = `
 `;
 
 exports[`renders correctly with value and options 1`] = `
-.c3 {
+.c2 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -222,7 +216,7 @@ exports[`renders correctly with value and options 1`] = `
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
-.c8 {
+.c7 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -230,7 +224,7 @@ exports[`renders correctly with value and options 1`] = `
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
-.c4 {
+.c3 {
   font-weight: normal;
   position: relative;
   box-sizing: border-box;
@@ -250,23 +244,23 @@ exports[`renders correctly with value and options 1`] = `
   margin-top: 0.5rem;
 }
 
-.c4:focus {
+.c3:focus {
   border: 1px solid #666;
 }
 
-.c4:focus::-webkit-input-placeholder {
+.c3:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c4:focus::-moz-placeholder {
+.c3:focus::-moz-placeholder {
   color: #666;
 }
 
-.c4:focus:-ms-input-placeholder {
+.c3:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c4:focus::placeholder {
+.c3:focus::placeholder {
   color: #666;
 }
 
@@ -286,7 +280,7 @@ exports[`renders correctly with value and options 1`] = `
   position: relative;
 }
 
-.c5 {
+.c4 {
   z-index: 3;
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
   position: absolute;
@@ -299,47 +293,45 @@ exports[`renders correctly with value and options 1`] = `
   width: 100%;
 }
 
-.c6 {
+.c5 {
   list-style: none;
   padding: 0;
   margin: 0;
 }
 
-.c7 {
+.c6 {
   padding: 0.5rem;
   cursor: pointer;
   border-top: 1px solid #F4F3F5;
 }
 
-.c7:hover {
+.c6:hover,
+.c6:focus {
   background-color: #F4F3F5;
 }
 
-.c2 input {
-  margin-top: 0.5rem;
-}
-
 @media (min-width:740px) {
-  .c4 {
+  .c3 {
     max-width: 290px;
   }
 }
 
 @media (min-width:740px) {
-  .c5 {
+  .c4 {
     max-width: 500px;
   }
 }
 
 <div
   className="c0 TextInputWithDropdown"
+  onKeyDown={[Function]}
 >
   <label
-    className="c1 c2 TextInputWithDropdown__input"
+    className="c1 TextInputWithDropdown__input"
     htmlFor="text-input-with-dropdown"
   >
     <span
-      className="c3 "
+      className="c2 "
       color="inherit"
       size="s"
     >
@@ -348,7 +340,7 @@ exports[`renders correctly with value and options 1`] = `
     <input
       aria-describedby="text-input-with-dropdown"
       autoComplete="off"
-      className="c4"
+      className="c3"
       id="text-input-with-dropdown"
       name="query"
       onChange={[Function]}
@@ -359,19 +351,25 @@ exports[`renders correctly with value and options 1`] = `
     
   </label>
   <div
-    className="c5 TextInputWithDropdown__options"
+    className="c4 TextInputWithDropdown__options"
+    tabIndex="0"
   >
     <ul
-      className="c6"
+      className="c5"
+      onBlur={[Function]}
+      role="listbox"
     >
       <li
-        className="c7"
+        aria-selected={false}
+        className="c6"
+        id="option-0"
         onClick={[Function]}
         onKeyPress={[Function]}
-        tabIndex="0"
+        role="option"
+        tabIndex="-1"
       >
         <span
-          className="c8"
+          className="c7"
           color="inherit"
           size="s"
         >
@@ -379,13 +377,16 @@ exports[`renders correctly with value and options 1`] = `
         </span>
       </li>
       <li
-        className="c7"
+        aria-selected={false}
+        className="c6"
+        id="option-1"
         onClick={[Function]}
         onKeyPress={[Function]}
-        tabIndex="0"
+        role="option"
+        tabIndex="-1"
       >
         <span
-          className="c8"
+          className="c7"
           color="inherit"
           size="s"
         >
@@ -393,13 +394,16 @@ exports[`renders correctly with value and options 1`] = `
         </span>
       </li>
       <li
-        className="c7"
+        aria-selected={false}
+        className="c6"
+        id="option-2"
         onClick={[Function]}
         onKeyPress={[Function]}
-        tabIndex="0"
+        role="option"
+        tabIndex="-1"
       >
         <span
-          className="c8"
+          className="c7"
           color="inherit"
           size="s"
         >
@@ -407,13 +411,16 @@ exports[`renders correctly with value and options 1`] = `
         </span>
       </li>
       <li
-        className="c7"
+        aria-selected={false}
+        className="c6"
+        id="option-3"
         onClick={[Function]}
         onKeyPress={[Function]}
-        tabIndex="0"
+        role="option"
+        tabIndex="-1"
       >
         <span
-          className="c8"
+          className="c7"
           color="inherit"
           size="s"
         >

--- a/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
+++ b/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
@@ -352,7 +352,6 @@ exports[`renders correctly with value and options 1`] = `
   </label>
   <div
     className="c4 TextInputWithDropdown__options"
-    tabIndex="0"
   >
     <ul
       className="c5"

--- a/src/components/Molecules/SchoolLookup/SchoolLookup.js
+++ b/src/components/Molecules/SchoolLookup/SchoolLookup.js
@@ -17,29 +17,34 @@ const optionFetcher = async query => {
 
 const optionParser = school => `${school.name}, ${school.post_code}`;
 
-const SchoolLookup = ({
-  label,
-  placeholder,
-  notFoundMessage,
-  dropdownInstruction,
-  onSelect,
-  ...rest
-}) => {
-  const props = {
-    optionFetcher,
-    optionParser,
-    onSelect,
-    id: 'school-lookup',
-    name: 'school-lookup',
-    label,
-    placeholder,
-    notFoundMessage,
-    dropdownInstruction,
-    ...rest
-  };
+const SchoolLookup = React.forwardRef(
+  (
+    {
+      label,
+      placeholder,
+      notFoundMessage,
+      dropdownInstruction,
+      onSelect,
+      ...rest
+    },
+    ref
+  ) => {
+    const props = {
+      optionFetcher,
+      optionParser,
+      onSelect,
+      id: 'school-lookup',
+      name: 'school-lookup',
+      label,
+      placeholder,
+      notFoundMessage,
+      dropdownInstruction,
+      ...rest
+    };
 
-  return <Typeahead {...props} />;
-};
+    return <Typeahead {...props} ref={ref} />;
+  }
+);
 
 SchoolLookup.propTypes = {
   /** This function is used to provide data to the parent component when a selection is made. */

--- a/src/components/Molecules/SchoolLookup/__snapshots__/SchoolLookup.test.js.snap
+++ b/src/components/Molecules/SchoolLookup/__snapshots__/SchoolLookup.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-.c3 {
+.c2 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -10,7 +10,7 @@ exports[`renders correctly 1`] = `
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
-.c4 {
+.c3 {
   font-weight: normal;
   position: relative;
   box-sizing: border-box;
@@ -30,23 +30,23 @@ exports[`renders correctly 1`] = `
   margin-top: 0.5rem;
 }
 
-.c4:focus {
+.c3:focus {
   border: 1px solid #666;
 }
 
-.c4:focus::-webkit-input-placeholder {
+.c3:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c4:focus::-moz-placeholder {
+.c3:focus::-moz-placeholder {
   color: #666;
 }
 
-.c4:focus:-ms-input-placeholder {
+.c3:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c4:focus::placeholder {
+.c3:focus::placeholder {
   color: #666;
 }
 
@@ -66,25 +66,22 @@ exports[`renders correctly 1`] = `
   position: relative;
 }
 
-.c2 input {
-  margin-top: 0.5rem;
-}
-
 @media (min-width:740px) {
-  .c4 {
+  .c3 {
     max-width: 290px;
   }
 }
 
 <div
   className="c0 TextInputWithDropdown"
+  onKeyDown={[Function]}
 >
   <label
-    className="c1 c2 TextInputWithDropdown__input"
+    className="c1 TextInputWithDropdown__input"
     htmlFor="school-lookup"
   >
     <span
-      className="c3 "
+      className="c2 "
       color="inherit"
       size="s"
     >
@@ -93,7 +90,7 @@ exports[`renders correctly 1`] = `
     <input
       aria-describedby="school-lookup"
       autoComplete="off"
-      className="c4"
+      className="c3"
       id="school-lookup"
       name="school-lookup"
       onChange={[Function]}

--- a/src/components/Molecules/Typeahead/Typeahead.js
+++ b/src/components/Molecules/Typeahead/Typeahead.js
@@ -12,74 +12,80 @@ const initialState = {
 };
 
 // These just felt about right to me but could be changed.
-const DELAY_DURATION = 200;
+const DELAY_DURATION = 300;
 const MIN_CHARS_FOR_FETCH = 2;
 
-const Typeahead = ({
-  optionFetcher,
-  optionParser,
-  onSelect,
-  id,
-  label,
-  name,
-  dropdownInstruction,
-  notFoundMessage,
-  fetchErrorHandler,
-  ...rest
-}) => {
-  const [state, updateState] = useStateObject(initialState);
+const Typeahead = React.forwardRef(
+  (
+    {
+      optionFetcher,
+      optionParser,
+      onSelect,
+      id,
+      label,
+      name,
+      dropdownInstruction,
+      notFoundMessage,
+      fetchErrorHandler,
+      ...rest
+    },
+    ref
+  ) => {
+    const [state, updateState] = useStateObject(initialState);
 
-  const debouncedFetch = useCallback(
-    debounce(async value => {
-      const valueTrimmed = value.trim();
-      let { options, errorMsg } = initialState;
-      if (valueTrimmed.length >= MIN_CHARS_FOR_FETCH) {
-        try {
-          options = await optionFetcher(valueTrimmed);
-          if (options.length === 0) {
-            errorMsg = notFoundMessage;
+    const debouncedFetch = useCallback(
+      debounce(async value => {
+        const valueTrimmed = value.trim();
+        let { options, errorMsg } = initialState;
+        if (valueTrimmed.length >= MIN_CHARS_FOR_FETCH) {
+          try {
+            options = await optionFetcher(valueTrimmed);
+            if (options.length === 0) {
+              errorMsg = notFoundMessage;
+            }
+          } catch (err) {
+            errorMsg = fetchErrorHandler(err);
           }
-        } catch (err) {
-          errorMsg = fetchErrorHandler(err);
+          updateState({ options, errorMsg });
         }
-        updateState({ options, errorMsg });
-      }
-    }, DELAY_DURATION),
-    []
-  );
+      }, DELAY_DURATION),
+      []
+    );
 
-  const onChange = e => {
-    const { value } = e.currentTarget;
-    // Resetting options / errorMsg as soon as the input changes seemed to me to be the nicest UX
-    // (but happy to take advice on this!)
-    const { options, errorMsg } = initialState;
-    updateState({ value, options, errorMsg });
-    debouncedFetch(value);
-  };
+    const onChange = e => {
+      const { value } = e.currentTarget;
+      // Resetting options / errorMsg as soon as the input changes seemed to me to be the nicest UX
+      // (but happy to take advice on this!)
+      const { options, errorMsg } = initialState;
+      updateState({ value, options, errorMsg });
+      debouncedFetch(value);
+    };
 
-  const { value, options, errorMsg } = state;
+    const { value, options, errorMsg } = state;
 
-  return (
-    <TextInputWithDropdown
-      value={value}
-      options={optionParser ? options.map(optionParser) : options}
-      errorMsg={errorMsg}
-      onChange={onChange}
-      onSelect={(v, index) => {
-        const selected = options[index];
-        // pass the selected value up to the parent via callback
-        onSelect(selected);
-        // reset
-        updateState(initialState);
-      }}
-      id={id}
-      label={label}
-      name={name}
-      dropdownInstruction={dropdownInstruction}
-      {...rest}
-    />
-  );
-};
+    return (
+      <TextInputWithDropdown
+        value={value}
+        options={optionParser ? options.map(optionParser) : options}
+        errorMsg={errorMsg}
+        onChange={onChange}
+        onSelect={(v, index) => {
+          const selected = options[index];
+          // pass the selected value up to the parent via callback
+          onSelect(selected);
+          // reset
+          updateState(initialState);
+        }}
+        id={id}
+        label={label}
+        name={name}
+        dropdownInstruction={dropdownInstruction}
+        {...rest}
+        ref={ref}
+      />
+    );
+  }
+);
 
 Typeahead.propTypes = {
   /** Takes the value and returns an array of options (e.g. by calling some lookup api.) */

--- a/src/components/Molecules/Typeahead/__snapshots__/Typeahead.test.js.snap
+++ b/src/components/Molecules/Typeahead/__snapshots__/Typeahead.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-.c3 {
+.c2 {
   font-size: 1rem;
   line-height: 1rem;
   text-transform: inherit;
@@ -10,7 +10,7 @@ exports[`renders correctly 1`] = `
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
 }
 
-.c4 {
+.c3 {
   font-weight: normal;
   position: relative;
   box-sizing: border-box;
@@ -30,23 +30,23 @@ exports[`renders correctly 1`] = `
   margin-top: 0.5rem;
 }
 
-.c4:focus {
+.c3:focus {
   border: 1px solid #666;
 }
 
-.c4:focus::-webkit-input-placeholder {
+.c3:focus::-webkit-input-placeholder {
   color: #666;
 }
 
-.c4:focus::-moz-placeholder {
+.c3:focus::-moz-placeholder {
   color: #666;
 }
 
-.c4:focus:-ms-input-placeholder {
+.c3:focus:-ms-input-placeholder {
   color: #666;
 }
 
-.c4:focus::placeholder {
+.c3:focus::placeholder {
   color: #666;
 }
 
@@ -66,25 +66,22 @@ exports[`renders correctly 1`] = `
   position: relative;
 }
 
-.c2 input {
-  margin-top: 0.5rem;
-}
-
 @media (min-width:740px) {
-  .c4 {
+  .c3 {
     max-width: 290px;
   }
 }
 
 <div
   className="c0 TextInputWithDropdown"
+  onKeyDown={[Function]}
 >
   <label
-    className="c1 c2 TextInputWithDropdown__input"
+    className="c1 TextInputWithDropdown__input"
     htmlFor="typeahead-test"
   >
     <span
-      className="c3 "
+      className="c2 "
       color="inherit"
       size="s"
     >
@@ -93,7 +90,7 @@ exports[`renders correctly 1`] = `
     <input
       aria-describedby="typeahead-test"
       autoComplete="off"
-      className="c4"
+      className="c3"
       id="typeahead-test"
       name="q"
       onChange={[Function]}

--- a/src/utils/makeOnEnterHandler.js
+++ b/src/utils/makeOnEnterHandler.js
@@ -1,8 +1,0 @@
-const makeOnEnterHandler = handler => e => {
-  const keyCode = e.keyCode || e.which;
-  if (keyCode === 13) {
-    handler(e);
-  }
-};
-
-export default makeOnEnterHandler;

--- a/src/utils/useStateObject.js
+++ b/src/utils/useStateObject.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import _ from 'lodash';
 
 /**
  * Hook to help with storing state in a single object in functional components and
@@ -7,7 +8,9 @@ import { useState } from 'react';
 const useStateObject = initialState => {
   const [state, setState] = useState(initialState);
   const updateState = updatedValues =>
-    setState(prevState => ({ ...prevState, ...updatedValues }));
+    setState(prevState =>
+      Object.assign(_.cloneDeep(prevState), _.cloneDeep(updatedValues))
+    );
 
   return [state, updateState];
 };


### PR DESCRIPTION
Type: patch

Fixes #313 

## Changes proposed in this PR

Improves keyboard support for the interrelated `SchoolLookup` / `Typeahead` / `TextInputWithDropdown` components

- Uses up/down arrows to navigate suggestions rather than tab
- Enables spacebar for selection (in addition to return) and escape to close the suggestions dropdown

Also adds 
- Some aria attributes
- Ref forwarding to these components