### PR TITLE
feat: update checkbox to accept children (if no label supplied)

### DIFF
--- a/cypress/integration/components/Atoms/Checkbox.spec.js
+++ b/cypress/integration/components/Atoms/Checkbox.spec.js
@@ -43,7 +43,7 @@ describe('Checkbox component', () => {
         it('should click checkboxes', () => {
             cy.get('[data-preview="Checkbox"] p').contains('List of checkboxes');
             cy.get('[data-testid="Checkbox-example-1"] div > label:nth-child(2)')
-                .contains('Tenis')
+                .contains('Tennis')
                 .click();
             cy.get('[data-testid="Checkbox-example-1"] div > label:nth-child(3)')
                 .contains('Basketball')

--- a/src/components/Atoms/Checkbox/Checkbox.js
+++ b/src/components/Atoms/Checkbox/Checkbox.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import Text from '../Text/Text';
 import checkBoxIcon from './assets/checkbox-white-tick.png';
 
-const StyledCheckboxInput = styled.input`
+const StyledCheckboxInput = styled.input.attrs({ type: 'checkbox' })`
   font-size: ${({ theme }) => theme.fontSize('sm')};
   display: block;
   box-sizing: border-box;
@@ -41,22 +41,30 @@ const StyledCheckboxInput = styled.input`
 
 const Label = styled.label`
   display: flex;
-  align-items: center;
+  ${({ hasLabelAsString }) => hasLabelAsString && 'align-items: center;'}
   margin-bottom: 8px;
 `;
 
-const Checkbox = React.forwardRef(({ label, value, ...rest }, ref) => (
-  <Label>
-    <StyledCheckboxInput type="checkbox" {...rest} value={value} ref={ref} />
+const Checkbox = React.forwardRef(({
+  label, value, children, ...rest
+}, ref) => (
+  <Label hasLabelAsString={!!label}>
+    <StyledCheckboxInput {...rest} value={value} ref={ref} />
     <span />
-    <Text weight="bold">{label}</Text>
+    {label ? <Text weight="bold">{label}</Text> : children}
   </Label>
 ));
 
 Checkbox.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired
+  label: PropTypes.string,
+  children: PropTypes.node
+};
+
+Checkbox.defaultProps = {
+  label: undefined,
+  children: undefined
 };
 
 export default Checkbox;

--- a/src/components/Atoms/Checkbox/Checkbox.md
+++ b/src/components/Atoms/Checkbox/Checkbox.md
@@ -1,9 +1,37 @@
 # CheckBox Field
 
 ```js
-<p> List of checkboxes </p>
-<Checkbox name="sport" value="Tenis" label="Tenis" />
-<Checkbox name="sport" value="Basketball" label="Basketball" />
-<Checkbox name="sport" value="Cycling" label="Cycling" />
-<Checkbox name="sport" value="Football" label="Football" />
+import Text from '../../Atoms/Text/Text';
+import Link from '../../Atoms/Link/Link';
+
+const LongLabel = () => (
+  <div>
+    <Text tag="p">
+      I agree to the
+      {' '}
+      <Link target="blank" href="https://comicrelief.com/terms-of-use/">terms and conditions</Link>
+      {' '}
+      and
+      {' '}
+      <Link target="blank" href="https://comicrelief.com/privacy-notice/">privacy policy.</Link>
+    </Text>
+    <Text tag="p">
+      For more information, please view our fundraising
+      <Link target="blank" href="https://comicrelief.com/code-of-conduct/">code of conduct.</Link>
+    </Text>
+  </div>
+);
+
+<>
+    <p>List of checkboxes</p>
+    <Checkbox name="sport" value="Tennis" label="Tennis" />
+    <Checkbox name="sport" value="Basketball" label="Basketball" />
+    <Checkbox name="sport" value="Cycling" label="Cycling" />
+    <Checkbox name="sport" value="Football" label="Football" />
+    <br/>
+    <p>A checkbox with a long label containing links</p>
+    <Checkbox name="node_label" value="node_label">
+      <LongLabel />
+    </Checkbox>
+</>
 ```


### PR DESCRIPTION
Closes: https://github.com/comicrelief/component-library/issues/339

Can either do this, or export the checkbox input as its own component?
