### PR TITLE
fix: Remove fixed height from TextArea component

### DIFF
--- a/src/components/Atoms/TextArea/TextArea.js
+++ b/src/components/Atoms/TextArea/TextArea.js
@@ -12,7 +12,6 @@ const StyledTextArea = styled.textarea`
   box-sizing: border-box;
   width: 100%;
   margin: 10px 0;
-  min-height: 65px;
   padding: 6px 12px;
   font-size: ${({ theme }) => theme.fontSize('m')};
   background-color: ${({ theme }) => theme.color('white')};
@@ -54,30 +53,24 @@ const StyledTextArea = styled.textarea`
     opacity: 1;
     overflow: visible;
   } /* IE 10+ */
-
-  @media ${({ theme }) => theme.breakpoint('small')} {
-    max-width: 100%;
-    height: 96px;
-  }
 `;
 
 /**
  * Label component
  */
-const Label = styled.label.attrs(({ id }) => ({
-  htmlFor: `${id}`
-}))`
+const Label = styled.label`
   display: flex;
   flex-direction: column;
 `;
 
 const TextArea = React.forwardRef(({
-  id, label, errorMsg, ...rest
+  id, label, errorMsg, rows, ...rest
 }, ref) => (
-  <Label>
+  <Label htmlFor={id}>
     <Text weight="bold">{label}</Text>
     <StyledTextArea
       {...rest}
+      rows={rows}
       error={!!errorMsg}
       aria-describedby={id}
       ref={ref}
@@ -91,7 +84,12 @@ TextArea.propTypes = {
   placeholder: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
-  errorMsg: PropTypes.string.isRequired
+  errorMsg: PropTypes.string.isRequired,
+  rows: PropTypes.number
+};
+
+TextArea.defaultProps = {
+  rows: 4
 };
 
 export default TextArea;

--- a/src/components/Atoms/TextArea/TextArea.md
+++ b/src/components/Atoms/TextArea/TextArea.md
@@ -6,10 +6,9 @@
   name="description"
   placeholder="This is text area"
   label="Label"
-  rows="5"
-  cols="5"
+  rows="4"
   errorMsg=""
-  id="Please leave your comment here"
+  id="textarea-test"
 />
 
 <h4>Long copy/Message field</h4>
@@ -17,9 +16,8 @@
   name="description"
   placeholder="This is text area"
   label="Label"
-  rows="5"
-  cols="5"
+  rows="6"
   errorMsg="This is an error message"
-  id="Please leave your comment here"
+  id="textarea-test-2"
 />
 ```

--- a/src/components/Atoms/TextArea/TextArea.test.js
+++ b/src/components/Atoms/TextArea/TextArea.test.js
@@ -30,7 +30,6 @@ it('renders correctly', () => {
       box-sizing: border-box;
       width: 100%;
       margin: 10px 0;
-      min-height: 65px;
       padding: 6px 12px;
       font-size: 1.25rem;
       background-color: #FFFFFF;
@@ -90,16 +89,9 @@ it('renders correctly', () => {
       flex-direction: column;
     }
 
-    @media (min-width:740px) {
-      .c2 {
-        max-width: 100%;
-        height: 96px;
-      }
-    }
-
     <label
       className="c0"
-      htmlFor="undefined"
+      htmlFor="Please leave your comment here"
     >
       <span
         className="c1"


### PR DESCRIPTION
Type: patch

Fixes #387

Fixed height prevents the use of the 'rows' attribute 