### PR TITLE
feat: Accept React component for <Input> label prop (as well as strings)

### DIFF
--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -89,7 +89,9 @@ const Input = React.forwardRef(
   ) => (
     // We need className here so that `styled(Input)` will work.
     <Label htmlFor={id} className={className} {...labelProps}>
-      <LabelText showLabel={showLabel} weight="bold" dangerouslySetInnerHTML={{ __html: label }} />
+      {React.isValidElement(label)
+        ? <LabelText showLabel={showLabel} weight="bold">{label}</LabelText>
+        : <LabelText showLabel={showLabel} weight="bold" dangerouslySetInnerHTML={{ __html: label }} />}
       <InputWrapper>
         {prefix && <Prefix length={prefix.length}>{prefix}</Prefix>}
         <InputField
@@ -109,7 +111,10 @@ const Input = React.forwardRef(
 
 Input.propTypes = {
   name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node
+  ]).isRequired,
   placeholder: PropTypes.string,
   errorMsg: PropTypes.string,
   // This prop allows us to _visually_ hide the label if we want (even if we

--- a/src/components/Atoms/Input/Input.md
+++ b/src/components/Atoms/Input/Input.md
@@ -1,5 +1,3 @@
-
-
 ```js
 <h4>Input required with label and hint</h4>
   <Input
@@ -7,7 +5,7 @@
     placeholder="This is the hint text"
     type="text"
     label="Label"
-    id="input-example"
+    id="input-example-1"
     showLabel={true}
   />
 ```

--- a/src/components/Atoms/Input/Input.md
+++ b/src/components/Atoms/Input/Input.md
@@ -1,3 +1,5 @@
+
+
 ```js
 <h4>Input required with label and hint</h4>
   <Input
@@ -5,7 +7,7 @@
     placeholder="This is the hint text"
     type="text"
     label="Label"
-    id="input-example-1"
+    id="input-example"
     showLabel={true}
   />
 ```
@@ -36,7 +38,6 @@
   />
 ```
 
-
 ```js
   <h4>Input Label with markup</h4>
   <Input
@@ -50,6 +51,27 @@
   />
 ```
 
+```js
+import styled from 'styled-components';
+import Text from '../../Atoms/Text/Text';
+
+const ItalicText = styled(Text).attrs({weight: 'normal'})`
+  font-style: italic
+`;
+
+<>
+  <h4>Input label as React element</h4>
+  <Input
+    name="email"
+    placeholder=""
+    type="text"
+    label={<>Email <ItalicText>(please check it's correct)</ItalicText></>}
+    errorMsg=""
+    id="input-example-5"
+    showLabel={true}
+  />
+</>
+```
 
 ```js
   <h4>Input with prefix</h4>


### PR DESCRIPTION
Wanted to be able to style the label as per Ruby's designs, without having to use HTML strings