### PR TITLE
fix: improve MP messaging, inline with Donate version

### DIFF
--- a/src/components/Organisms/MarketingPreferencesDS/_MarketingPreferencesDS.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_MarketingPreferencesDS.js
@@ -87,9 +87,8 @@ const MarketingPreferencesDS = ({
         </Head>
 
         <MaybeDisabled disabled={disableEmailInput}>
-          {/* DEBUG */}
           <ShowHideInputWrapper show={showEmailField}>
-            {emailChoice[0] === 'no' && <NoMessage askingFor="an email" /> }
+            {emailChoice[0] === 'no' && <NoMessage askingFor="an email" optInType="email" /> }
             <TextInput
               placeholder=""
               fieldName="mp_email"
@@ -122,7 +121,7 @@ const MarketingPreferencesDS = ({
         </Head>
         <MaybeDisabled disabled={disableSMSInput}>
           <ShowHideInputWrapper show={showSMSField}>
-            {smsChoice[0] === 'no' && <NoMessage askingFor="a mobile number" />}
+            {smsChoice[0] === 'no' && <NoMessage askingFor="a mobile number" optInType="SMS" />}
             <TextInput
               placeholder=""
               fieldName="mp_mobile"
@@ -153,7 +152,7 @@ const MarketingPreferencesDS = ({
         </Head>
         <MaybeDisabled disabled={disablePhoneInput}>
           <ShowHideInputWrapper show={showPhoneField}>
-            {phoneChoice[0] === 'no' ? <NoMessage askingFor="a phone number" /> : ''}
+            {phoneChoice[0] === 'no' ? <NoMessage askingFor="a phone number" optInType="phone" /> : ''}
             <TextInput
               placeholder=""
               fieldName="mp_phone"
@@ -184,7 +183,7 @@ const MarketingPreferencesDS = ({
         </Head>
         <MaybeDisabled disabled={disablePostInput}>
           <ShowHideInputWrapper show={showPostFields}>
-            {postChoice[0] === 'no' ? <NoMessage askingFor="an address" /> : ''}
+            {postChoice[0] === 'no' ? <NoMessage askingFor="an address" optInType="postal" /> : ''}
             <TextInput
               placeholder=""
               fieldName="mp_address1"

--- a/src/components/Organisms/MarketingPreferencesDS/_NoMessage.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_NoMessage.js
@@ -1,17 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
 import Text from '../../Atoms/Text/Text';
 
-const NoMessage = ({ askingFor }) => {
-  const message = `This will remove the supplied ${askingFor} from any *previous* phone opt-in from our database; otherwise, you can leave this unchecked.`;
+const NoMessageWrapper = styled.div`${({ theme }) => css`
+  padding: 15px;
+  background-color: ${theme.color('red')};
+  margin-bottom: 15px;
+`}`;
+
+const NoMessage = ({ askingFor, optInType }) => {
+  const message = `This will remove the supplied ${askingFor} from any *previous* ${optInType} opt-in from our database; otherwise, you can leave this unchecked.`;
 
   return (
-    <Text tag="p" size="s" color="grey_dark">{message}</Text>
+    <NoMessageWrapper>
+      <Text tag="p" size="s" color="white">{message}</Text>
+    </NoMessageWrapper>
   );
 };
 
 NoMessage.propTypes = {
-  askingFor: PropTypes.string.isRequired
+  askingFor: PropTypes.string.isRequired,
+  optInType: PropTypes.string.isRequired
 };
 
 export default NoMessage;

--- a/src/components/Organisms/MarketingPreferencesDS/_NoMessage.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_NoMessage.js
@@ -4,8 +4,8 @@ import styled, { css } from 'styled-components';
 import Text from '../../Atoms/Text/Text';
 
 const NoMessageWrapper = styled.div`${({ theme }) => css`
-  padding: 15px;
   background-color: ${theme.color('red')};
+  padding: 15px;
   margin-bottom: 15px;
 `}`;
 

--- a/src/components/Organisms/MarketingPreferencesDS/_NoMessage.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_NoMessage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Text from '../../Atoms/Text/Text';
 
 const NoMessage = ({ askingFor }) => {
-  const message = `Please provide ${askingFor} so we can remove it from our database, otherwise untick this option.`;
+  const message = `This will remove the supplied ${askingFor} from any *previous* phone opt-in from our database; otherwise, you can leave this unchecked.`;
 
   return (
     <Text tag="p" size="s" color="grey_dark">{message}</Text>


### PR DESCRIPTION
Something that I noticed during work for https://github.com/comicrelief/comicrelief-contentful/pull/1102, this brings in the same improvements made to MP messaging that were added to the Donation version just before RND22