### PR TITLE
fix: Reset associated MP fields when option unselected

### DIFF
--- a/src/components/Organisms/MarketingPreferencesDS/_CheckAnswer.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_CheckAnswer.js
@@ -19,6 +19,12 @@ const CheckAnswer = ({
       newVal = e.target.value === 'yes' ? e.target.value : 'no';
     } else {
       newVal = '';
+
+      // To ensure we're not letting invalid values get passed, reset any associated fields:
+      const theseFields = AssociatedFields[name];
+      theseFields.forEach(fieldName => {
+        setValue(fieldName, '');
+      });
     }
 
     // Update the checkbox field itself

--- a/src/components/Organisms/MarketingPreferencesDS/_MarketingPreferencesDS.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_MarketingPreferencesDS.js
@@ -57,7 +57,6 @@ const MarketingPreferencesDS = ({
     return errors.mp_address1 || errors.mp_address2
     || errors.mp_address3 || errors.mp_town || errors.mp_country || errors.mp_postcode;
   };
-
   /* Only show the field if config hasn't hidden it (to pass in parent values)
     or if a choice has been made */
   const showEmailField = !mp_permissionEmail.hideInput && (emailChoice.length || errors.mp_email);

--- a/src/components/Organisms/MarketingPreferencesDS/_MarketingPreferencesDS.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_MarketingPreferencesDS.js
@@ -57,6 +57,7 @@ const MarketingPreferencesDS = ({
     return errors.mp_address1 || errors.mp_address2
     || errors.mp_address3 || errors.mp_town || errors.mp_country || errors.mp_postcode;
   };
+
   /* Only show the field if config hasn't hidden it (to pass in parent values)
     or if a choice has been made */
   const showEmailField = !mp_permissionEmail.hideInput && (emailChoice.length || errors.mp_email);


### PR DESCRIPTION
Type: patch

Fixes #https://comicrelief.atlassian.net/browse/ENG-1520

## Changes proposed in this PR

- As per the ticket, when a MP option is toggled on, a value is supplied, then then toggle off again, we want to ensure we're not accidentally able to submit unvalidated values.
- Sooooo we're resetting all fields associated with the checkbox option

