### PR TITLE
feat: add Styled Components babel plugin for better CSS classnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.0.2",
+    "babel-plugin-styled-components": "^1.12.0",
     "cross-env": "^7.0.3",
     "cypress": "^8.3.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
What is it doing?
Adds babel plugin to dev dependencies so that CSS classnames make reference to the Component name, rather than just dynamically generated hash.

Why is this required?
Very hard to debug CSS style issues with just dynamically generated classnames like rh5b2$h
