### PR TITLE
docs: fixed a couple of typos

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,10 +3,10 @@
 CR-CL has a dependency of Styled-components.
 
 #### Install the package
-`yarn add @comicrelief/component-library`
+`yarn add @comicrelief/component-library` 
 
 #### Wrap your app with the ThemeProvider and crTheme
-`import { ThemeProvider, theme as crTheme } from '@comic-relief/component-library';`
+`import { ThemeProvider, crTheme } from '@comicrelief/component-library';`
 
 #### Import components
-`import { HeroBanner } from '@comic-relief/component-library';`
+`import { HeroBanner } from '@comicrelief/component-library';`

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   getComponentPathLine(componentPath) {
     const name = path.basename(componentPath, '.js');
-    return `import { ${name} } from '@comic-relief/component-library';`;
+    return `import { ${name} } from '@comicrelief/component-library';`;
   },
   assetsDir: 'src/styleguide/assets/',
   styleguideComponents: {


### PR DESCRIPTION
Type: patch

Fixes documentation error with library name.

## Changes proposed in this PR

- Changed all references to comic-relief to comicrelief