### PR TITLE
fix: rename Radio to RadioButton.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export { default as Logo } from './components/Atoms/Logo/Logo';
 export { default as Picture } from './components/Atoms/Picture/Picture';
 export { default as Link } from './components/Atoms/Link/Link';
 export { default as Button } from './components/Atoms/Button/Button';
-export { default as Radio } from './components/Atoms/RadioButton/RadioButton';
+export { default as RadioButton } from './components/Atoms/RadioButton/RadioButton';
 export { default as Checkbox } from './components/Atoms/Checkbox/Checkbox';
 export { default as Input } from './components/Atoms/Input/Input';
 export { default as Select } from './components/Atoms/Select/Select';


### PR DESCRIPTION
#### What is it doing?
Rename the export name of `Radio` to `RadioButton`

#### Why is this required?
Cleans up the exports to keep this inline with the rest of the exports, also prevents any confusion over the naming.
