### PR TITLE
feat: add optional label and required prop to select component

### DIFF
--- a/src/components/Atoms/Select/Select.js
+++ b/src/components/Atoms/Select/Select.js
@@ -49,6 +49,7 @@ const Select = React.forwardRef(
       onChange,
       greyDescription,
       className,
+      optional,
       ...rest
     },
     ref
@@ -56,7 +57,13 @@ const Select = React.forwardRef(
     const [value, setValue] = useState('');
 
     return (
-      <Label label={label} hideLabel={hideLabel} errorMsg={errorMsg} className={className}>
+      <Label
+        label={label}
+        hideLabel={hideLabel}
+        errorMsg={errorMsg}
+        className={className}
+        optional={optional}
+      >
         <StyledSelect
           onChange={e => {
             setValue(e.currentTarget.value);
@@ -102,7 +109,8 @@ Select.propTypes = {
   greyDescription: PropTypes.bool,
   // className is needed so that styled(`Select`) will work
   // (as `rest` is not spread on the outermost component)
-  className: PropTypes.string
+  className: PropTypes.string,
+  optional: PropTypes.bool
 };
 
 Select.defaultProps = {
@@ -112,7 +120,8 @@ Select.defaultProps = {
   /** If true, the 'description' option, which is initially selected but disabled, will be grey
    *   - like a text input's placeholder */
   greyDescription: false,
-  className: ''
+  className: '',
+  optional: false
 };
 
 export default Select;

--- a/src/components/Atoms/Select/Select.js
+++ b/src/components/Atoms/Select/Select.js
@@ -74,6 +74,7 @@ const Select = React.forwardRef(
           {...rest}
           error={errorMsg}
           defaultValue={defaultValue}
+          required={optional === false}
           hasValue={!!value}
           greyDescription={greyDescription}
           ref={ref}

--- a/src/components/Atoms/Select/__snapshots__/Select.test.js.snap
+++ b/src/components/Atoms/Select/__snapshots__/Select.test.js.snap
@@ -78,6 +78,7 @@ exports[`renders correctly 1`] = `
     className="c3"
     defaultValue=""
     onChange={[Function]}
+    required={true}
   >
     <option
       disabled={true}

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -231,6 +231,7 @@ exports[`renders ESU School correctly 1`] = `
         defaultValue=""
         onChange={[Function]}
         placeholder="Please choose an option"
+        required={true}
         value=""
       >
         <option


### PR DESCRIPTION
#### What is it doing?

- Adds the `optional` label prop to the select component.
- Adds the `required` flag to the select component.

#### Why is this required?
Allows for more clarity when select fields are not required.
