### PR TITLE
fix: adjust span spacer as creates issue with long labels

### DIFF
--- a/src/components/Atoms/Checkbox/Checkbox.js
+++ b/src/components/Atoms/Checkbox/Checkbox.js
@@ -24,6 +24,7 @@ const StyledCheckboxInput = styled.input.attrs({ type: 'checkbox' })`
     background-color: ${({ theme }) => theme.color('white')};
     border: 1px solid ${({ theme }) => theme.color('grey')};
     float: left;
+    flex-shrink: 0;
   }
   :checked + span {
     background: url(${checkBoxIcon}) no-repeat center;

--- a/src/components/Atoms/Checkbox/Checkbox.test.js
+++ b/src/components/Atoms/Checkbox/Checkbox.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
-import Checkbox from './Checkbox';
+import React from "react";
+import "jest-styled-components";
+import renderWithTheme from "../../../hoc/shallowWithTheme";
+import Checkbox from "./Checkbox";
 
-it('renders correctly', () => {
+it("renders correctly", () => {
   const tree = renderWithTheme(
     <>
       <Checkbox name="sport" value="Tenis" label="Tenis" />
@@ -13,7 +13,7 @@ it('renders correctly', () => {
 
   expect(tree).toMatchInlineSnapshot(`
     Array [
-    .c2 {
+      .c2 {
       font-size: 1rem;
       line-height: 1rem;
       text-transform: inherit;
@@ -42,6 +42,8 @@ it('renders correctly', () => {
       background-color: #FFFFFF;
       border: 1px solid #969598;
       float: left;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
       flex-shrink: 0;
     }
 
@@ -116,6 +118,9 @@ it('renders correctly', () => {
       background-color: #FFFFFF;
       border: 1px solid #969598;
       float: left;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
     }
 
     .c1:checked + span {
@@ -142,22 +147,24 @@ it('renders correctly', () => {
       margin-bottom: 8px;
     }
 
-    <label className="c0">
-      <input
-        className="c1"
-        name="sport"
-        type="checkbox"
-        value="Handball"
-      />
-      <span />
-      <span
-        className="c2"
-        color="inherit"
-        size="s"
+    <label
+        className="c0"
       >
-        Handball
-      </span>
-    </label>,
+        <input
+          className="c1"
+          name="sport"
+          type="checkbox"
+          value="Handball"
+        />
+        <span />
+        <span
+          className="c2"
+          color="inherit"
+          size="s"
+        >
+          Handball
+        </span>
+      </label>,
     ]
   `);
 });

--- a/src/components/Atoms/Checkbox/Checkbox.test.js
+++ b/src/components/Atoms/Checkbox/Checkbox.test.js
@@ -13,7 +13,7 @@ it('renders correctly', () => {
 
   expect(tree).toMatchInlineSnapshot(`
     Array [
-      .c2 {
+    .c2 {
       font-size: 1rem;
       line-height: 1rem;
       text-transform: inherit;
@@ -42,6 +42,7 @@ it('renders correctly', () => {
       background-color: #FFFFFF;
       border: 1px solid #969598;
       float: left;
+      flex-shrink: 0;
     }
 
     .c1:checked + span {
@@ -141,24 +142,22 @@ it('renders correctly', () => {
       margin-bottom: 8px;
     }
 
-    <label
-        className="c0"
+    <label className="c0">
+      <input
+        className="c1"
+        name="sport"
+        type="checkbox"
+        value="Handball"
+      />
+      <span />
+      <span
+        className="c2"
+        color="inherit"
+        size="s"
       >
-        <input
-          className="c1"
-          name="sport"
-          type="checkbox"
-          value="Handball"
-        />
-        <span />
-        <span
-          className="c2"
-          color="inherit"
-          size="s"
-        >
-          Handball
-        </span>
-      </label>,
+        Handball
+      </span>
+    </label>,
     ]
   `);
 });

--- a/src/components/Atoms/Checkbox/Checkbox.test.js
+++ b/src/components/Atoms/Checkbox/Checkbox.test.js
@@ -1,9 +1,9 @@
-import React from "react";
-import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
-import Checkbox from "./Checkbox";
+import React from 'react';
+import 'jest-styled-components';
+import renderWithTheme from '../../../hoc/shallowWithTheme';
+import Checkbox from './Checkbox';
 
-it("renders correctly", () => {
+it('renders correctly', () => {
   const tree = renderWithTheme(
     <>
       <Checkbox name="sport" value="Tenis" label="Tenis" />


### PR DESCRIPTION
### PR description
#### What is it doing?
Adjust span spacer as part of the Checkbox.js component, as it creates an issue with long labels.

#### Why is this required?
As part of new FSU journey, the checkbox on step 2, terms and conditions, shrinks to unusable size on mobile view.

#### link to Jira ticket:
[Add a link to the Jira ticket.](https://comicrelief.atlassian.net/browse/ENG-1764)
