### PR TITLE
fix: fix no spacing issue on radio button

### DIFF
--- a/src/components/Atoms/RadioButton/RadioButton.js
+++ b/src/components/Atoms/RadioButton/RadioButton.js
@@ -18,6 +18,7 @@ const StyledRadioInput = styled.input`
   opacity: 0;
   left: 0;
   right: 0;
+  flex-shrink: 0;
   + span {
     left: 2px;
     border-radius: 30px;

--- a/src/components/Atoms/RadioButton/RadioButton.test.js
+++ b/src/components/Atoms/RadioButton/RadioButton.test.js
@@ -1,9 +1,9 @@
-import React from "react";
-import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
-import RadioButton from "./RadioButton";
+import React from 'react';
+import 'jest-styled-components';
+import renderWithTheme from '../../../hoc/shallowWithTheme';
+import RadioButton from './RadioButton';
 
-it("renders correctly", () => {
+it('renders correctly', () => {
   const tree = renderWithTheme(
     <>
       <RadioButton id="male" name="gender" value="male" label="Male" />

--- a/src/components/Atoms/RadioButton/RadioButton.test.js
+++ b/src/components/Atoms/RadioButton/RadioButton.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
-import RadioButton from './RadioButton';
+import React from "react";
+import "jest-styled-components";
+import renderWithTheme from "../../../hoc/shallowWithTheme";
+import RadioButton from "./RadioButton";
 
-it('renders correctly', () => {
+it("renders correctly", () => {
   const tree = renderWithTheme(
     <>
       <RadioButton id="male" name="gender" value="male" label="Male" />
@@ -32,6 +32,9 @@ it('renders correctly', () => {
       opacity: 0;
       left: 0;
       right: 0;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
     }
 
     .c1 + span {
@@ -116,6 +119,9 @@ it('renders correctly', () => {
       opacity: 0;
       left: 0;
       right: 0;
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
     }
 
     .c1 + span {


### PR DESCRIPTION
#### What is it doing?

Same fix as with the checkbox component, stops the spacing from collapsing.

#### Why is this required?

Same issue as with the checkbox component, causing the spacing to collapse with a larger amount of text:

![Problem](https://user-images.githubusercontent.com/4737220/189099327-022e944d-59ee-4415-bf5b-4ff69d713d16.jpg)
