### PR TITLE
fix: fix header for in-situ usage

### DIFF
--- a/src/components/Atoms/Logo/Logo.js
+++ b/src/components/Atoms/Logo/Logo.js
@@ -68,7 +68,7 @@ Logo.propTypes = {
 Logo.defaultProps = {
   rotate: false,
   sizeSm: '51px', // - to work with the header 75px height and 12px padding
-  sizeMd: '75px',
+  sizeMd: '70px',
   campaign: 'Comic Relief'
 };
 

--- a/src/components/Atoms/Logo/Logo.js
+++ b/src/components/Atoms/Logo/Logo.js
@@ -67,7 +67,7 @@ Logo.propTypes = {
 
 Logo.defaultProps = {
   rotate: false,
-  sizeSm: '75px',
+  sizeSm: '51px',
   sizeMd: '75px',
   campaign: 'Comic Relief'
 };

--- a/src/components/Atoms/Logo/Logo.js
+++ b/src/components/Atoms/Logo/Logo.js
@@ -67,7 +67,7 @@ Logo.propTypes = {
 
 Logo.defaultProps = {
   rotate: false,
-  sizeSm: '51px',
+  sizeSm: '51px', // - to work with the header 75px height and 12px padding
   sizeMd: '75px',
   campaign: 'Comic Relief'
 };

--- a/src/components/Atoms/Logo/Logo.test.js
+++ b/src/components/Atoms/Logo/Logo.test.js
@@ -18,7 +18,7 @@ it("renders correctly", () => {
     .c0 {
       display: inline-block;
       z-index: 3;
-      width: 75px;
+      width: 51px;
       -webkit-transform: rotate(-14deg);
       -ms-transform: rotate(-14deg);
       transform: rotate(-14deg);
@@ -27,7 +27,7 @@ it("renders correctly", () => {
 
     @media (min-width:1150px) {
       .c0 {
-        width: 75px;
+        width: 70px;
       }
     }
 

--- a/src/components/Organisms/Header/Header.style.js
+++ b/src/components/Organisms/Header/Header.style.js
@@ -21,7 +21,7 @@ const InnerWrapper = styled.div`
   display: flex;
   align-items: center;
   height: 100%;
-  padding: 0;
+  padding: 0 12px;
   cursor: pointer;
   max-width: ${container.large};
 


### PR DESCRIPTION
### PR description
#### What is it doing?
I overlooked the fact that the CL is actually adding padding to its examples:

![Screenshot 2022-09-15 at 10 30 33](https://user-images.githubusercontent.com/4737220/190369030-dee9d77e-f4d6-4f10-9a53-04344ad6b337.png)

So, within the real context:

#### Why is this required?
IT LOOKS BAD

![Screenshot 2022-09-15 at 10 04 25](https://user-images.githubusercontent.com/4737220/190368662-2dec7813-7d94-4d38-9ef5-a9d59f6f1f3b.png)
![Screenshot 2022-09-15 at 10 04 31](https://user-images.githubusercontent.com/4737220/190368693-217d95fe-f1b7-4ba9-b4b9-c0bad81c5615.png)

#### link to Jira ticket:
Same ticket as before, although I'm not going to _hyperlink_ it, as it'll annoyingly close the ticket AGAIN before I get a chance to get int into CR properly - comicrelief.atlassian.net/browse/ENG-1784
