### PR TITLE
fix: use alternative Media Query function

### DIFF
--- a/src/components/Organisms/Donate/Donate.js
+++ b/src/components/Organisms/Donate/Donate.js
@@ -1,8 +1,9 @@
+/* eslint-disable no-unused-vars */
 import React from 'react';
-import { useMediaQuery } from 'react-responsive';
+import MediaQuery from 'react-responsive';
 import PropTypes from 'prop-types';
 
-import { screen } from '../../../theme/shared/size';
+import { screenPixelValues } from '../../../theme/shared/size';
 import Text from '../../Atoms/Text/Text';
 import Picture from '../../Atoms/Picture/Picture';
 import Form from './Form/Form';
@@ -36,76 +37,76 @@ const Donate = ({
   noMoneyBuys,
   PopUpText,
   chooseAmountText
-}) => {
-  const isDesktop = useMediaQuery({ query: `(min-width: ${screen.medium})` });
+}) => (
+  <Container backgroundColor={backgroundColor} id={mbshipID}>
+    {mobileImages && (
+    <MediaQuery maxWidth={screenPixelValues.medium - 1}>
+      <Picture
+        backgroundColor={backgroundColor}
+        image={mobileImage}
+        images={mobileImages}
+        imageLow={mobileImageLow}
+        objectFit="cover"
+        width="100%"
+        height="100%"
+        alt={mobileAlt}
+      />
+    </MediaQuery>
+    )}
 
-  return (
-    <Container backgroundColor={backgroundColor} id={mbshipID}>
-      {!isDesktop && mobileImages ? (
-        <Picture
-          backgroundColor={backgroundColor}
-          image={mobileImage}
-          images={mobileImages}
-          imageLow={mobileImageLow}
-          objectFit="cover"
-          width="100%"
-          height="100%"
-          alt={mobileAlt}
-        />
-      ) : null}
+    {images && (
+    <MediaQuery minWidth={screenPixelValues.medium}>
+      <BgImage
+        backgroundColor={backgroundColor}
+        image={image}
+        images={images}
+        imageLow={imageLow}
+        objectFit="cover"
+        width="100%"
+        height="100%"
+        alt={alt}
+        isBackgroundImage
+      />
+    </MediaQuery>
+    )}
 
-      {isDesktop && images ? (
-        <BgImage
-          backgroundColor={backgroundColor}
-          image={image}
-          images={images}
-          imageLow={imageLow}
-          objectFit="cover"
-          width="100%"
-          height="100%"
-          alt={alt}
-          isBackgroundImage
-        />
-      ) : null}
+    <Wrapper formAlignRight={formAlignRight} aria-live="polite">
+      <Header formAlignRight={formAlignRight}>
+        <HeaderInner>
+          {subtitle && (
+          <>
+            <Text
+              tag="h2"
+              color="white"
+              size="big"
+              family="Anton"
+              weight="normal"
+              uppercase
+            >
+              {title}
+            </Text>
+            <Text tag="p" color="white" size="m">
+              {subtitle}
+            </Text>
+          </>
+          )}
+        </HeaderInner>
+      </Header>
 
-      <Wrapper formAlignRight={formAlignRight} aria-live="polite">
-        <Header formAlignRight={formAlignRight}>
-          <HeaderInner>
-            {subtitle && (
-              <>
-                <Text
-                  tag="h2"
-                  color="white"
-                  size="big"
-                  family="Anton"
-                  weight="normal"
-                  uppercase
-                >
-                  {title}
-                </Text>
-                <Text tag="p" color="white" size="m">
-                  {subtitle}
-                </Text>
-              </>
-            )}
-          </HeaderInner>
-        </Header>
-
-        <Form
-          data={data}
-          otherDescription={otherDescription}
-          cartID={cartID}
-          clientID={clientID}
-          mbshipID={mbshipID}
-          donateLink={donateLink}
-          noMoneyBuys={noMoneyBuys}
-          PopUpText={PopUpText}
-          chooseAmountText={chooseAmountText}
-        />
-      </Wrapper>
-    </Container>
-  );
-};
+      <Form
+        data={data}
+        otherDescription={otherDescription}
+        cartID={cartID}
+        clientID={clientID}
+        mbshipID={mbshipID}
+        donateLink={donateLink}
+        noMoneyBuys={noMoneyBuys}
+        PopUpText={PopUpText}
+        chooseAmountText={chooseAmountText}
+      />
+    </Wrapper>
+  </Container>
+);
 
 Donate.propTypes = {
   alt: PropTypes.string,

--- a/src/components/Organisms/Donate/Donate.js
+++ b/src/components/Organisms/Donate/Donate.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import React from 'react';
 import MediaQuery from 'react-responsive';
 import PropTypes from 'prop-types';

--- a/src/components/Organisms/Donate/GivingSelector/GivingSelector.js
+++ b/src/components/Organisms/Donate/GivingSelector/GivingSelector.js
@@ -123,7 +123,7 @@ const GivingSelector = ({ givingType, changeGivingType, setPopOpen }) => (
 GivingSelector.propTypes = {
   givingType: PropTypes.string.isRequired,
   changeGivingType: PropTypes.func.isRequired,
-  setPopOpen: PropTypes.bool.isRequired
+  setPopOpen: PropTypes.func.isRequired
 };
 
 export default GivingSelector;

--- a/src/theme/shared/size.js
+++ b/src/theme/shared/size.js
@@ -1,7 +1,13 @@
+const screenPixelValues = {
+  small: 740,
+  medium: 1024,
+  large: 1440
+};
+
 const screen = {
-  small: '740px',
-  medium: '1024px',
-  large: '1440px'
+  small: `${screenPixelValues.small}px`,
+  medium: `${screenPixelValues.medium}px`,
+  large: `${screenPixelValues.large}px`
 };
 
 const media = size => {
@@ -17,4 +23,6 @@ const container = {
   large: '1440px'
 };
 
-export { media, screen, container };
+export {
+  media, screen, container, screenPixelValues
+};


### PR DESCRIPTION
We're currently using this in the CRcom integration of the Promo without any issues, so I'm hoping this'll solve the issue we were seeing :

![image](https://user-images.githubusercontent.com/4737220/195667745-c8833971-0067-407b-a272-26d0fbef03d4.png)

(Slack thread [here](https://comicrelief.slack.com/archives/C041U74BL/p1665671885014529))

I can confirm this is due to the 'isDesktop' variable not being set in time for initial render; I could recreate this locally by removing the variable assign.