### PR TITLE
feat: add chevrons to mobile view as well 

### DIFF
--- a/src/components/Organisms/Header/Nav/Nav.js
+++ b/src/components/Organisms/Header/Nav/Nav.js
@@ -100,6 +100,13 @@ const MainNav = ({ navItems }) => {
                     role="button"
                   >
                     {thisFirstChild.title}
+                    {hasSubMenu
+                      && (
+                      <ChevronWrapper>
+                        <img src={chevronDown} alt="chevron down icon" />
+                      </ChevronWrapper>
+                      )
+                    }
                   </NavLink>
                 ) : (
                   <Text>

--- a/src/components/Organisms/Header/Nav/Nav.js
+++ b/src/components/Organisms/Header/Nav/Nav.js
@@ -7,7 +7,7 @@ import { sizes } from '../../../../theme/shared/breakpoint';
 import NavHelper from '../../../../utils/navHelper';
 import { InternalLinkHelper } from '../../../../utils/internalLinkHelper';
 import whiteListed from '../../../../utils/whiteListed';
-import ChevronDown from './chevron-down.svg';
+import chevronDown from './chevron-down.svg';
 
 import {
   Nav,
@@ -114,7 +114,7 @@ const MainNav = ({ navItems }) => {
                       {hasSubMenu
                         && (
                         <ChevronWrapper>
-                          <img src={ChevronDown} alt="chevron down icon" />
+                          <img src={chevronDown} alt="chevron down icon" />
                         </ChevronWrapper>
                         )
                       }


### PR DESCRIPTION
### PR description
#### What is it doing?
Add chevrons to mobile view.

#### Why is this required?
Got wires crossed and thought they were only for dekstop view.

#### link to Jira ticket:
https://comicrelief.atlassian.net/browse/ENG-1740
