### PR TITLE
fix: Make ESU error handling more explicit

### DIFF
--- a/src/components/Organisms/EmailSignUp/EmailSignUpForm.js
+++ b/src/components/Organisms/EmailSignUp/EmailSignUpForm.js
@@ -14,7 +14,7 @@ const EmailSignUpForm = () => {
     mode: 'onBlur',
     resolver: yupResolver(validationSchema)
   });
-  const { handleSubmit, trigger } = formMethods;
+  const { handleSubmit, trigger, setError } = formMethods;
 
   async function handleSubscribe(data) {
     const valid = await trigger([
@@ -25,6 +25,8 @@ const EmailSignUpForm = () => {
     if (valid) {
       // eslint-disable-next-line no-console
       console.log(data);
+    } else {
+      setError('formError', { message: 'Error' });
     }
   }
   const title = 'Stay in the know!';

--- a/src/components/Organisms/EmailSignUp/_EmailSignUp.js
+++ b/src/components/Organisms/EmailSignUp/_EmailSignUp.js
@@ -102,12 +102,12 @@ const EmailSignUp = ({
         <>
           {/*
             Field errors will prevent submission,
-            so theoretically this should just be a single error set in the submission callback
-            with with RHF's `setError` method, but will neatly display multiple errors.
+            so theoretically the first error should set in the submission callback
+            with with RHF's `setError` method.
           */}
-          {Object.values(errors).map(error => (
-            <ErrorText>{error.message}</ErrorText>
-          ))}
+          {errors.formError !== undefined && (
+            <ErrorText>{errors.formError.message}</ErrorText>
+          )}
         </>
       )}
 

--- a/src/components/Organisms/EmailSignUp/_EmailSignUp.js
+++ b/src/components/Organisms/EmailSignUp/_EmailSignUp.js
@@ -100,11 +100,8 @@ const EmailSignUp = ({
       )}
       {isSubmitted && !isSubmitSuccessful && (
         <>
-          {/*
-            Field errors will prevent submission,
-            so theoretically the first error should set in the submission callback
-            with with RHF's `setError` method.
-          */}
+          {/* This error can be set as part of the submit callback using RHF's `setError` function.
+          e.g. setError('formError', { message: 'Some error message'}) */}
           {errors.formError !== undefined && (
             <ErrorText>{errors.formError.message}</ErrorText>
           )}


### PR DESCRIPTION
#### What is it doing?

Sets a specific custom error called 'formError' that will be used for capturing errors as part of the submit callback. Allows us to be explicit about what errors we wish to show.

#### Why is this required?

Previous implementation was also showing field errors in certain situations, as these should be displayed in the field itself, it could be confusing so this clears that up.
