### PR TITLE
fix: make MP field values persist when hidden

### DIFF
--- a/src/components/Organisms/MarketingPreferencesDS/MarketingPreferencesDSForm.js
+++ b/src/components/Organisms/MarketingPreferencesDS/MarketingPreferencesDSForm.js
@@ -41,9 +41,9 @@ const {
 } = mpValidationCustom;
 
 const MarketingPreferencesDSForm = () => {
-  function customSubmitHandler() {
+  function customSubmitHandler(formData) {
     // eslint-disable-next-line no-console
-    console.log('Successful submission');
+    console.log('Successful submission', formData);
   }
 
   // For our default instance:

--- a/src/components/Organisms/MarketingPreferencesDS/_CheckAnswer.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_CheckAnswer.js
@@ -20,11 +20,14 @@ const CheckAnswer = ({
     } else {
       newVal = '';
 
-      // To ensure we're not letting invalid values get passed, reset any associated fields:
-      const theseFields = AssociatedFields[name].fieldNames;
-      theseFields.forEach(fieldName => {
-        setValue(fieldName, '');
-      });
+      // To ensure we're not letting invalid values get passed, reset any associated fields
+      // but only when it's not a hidden "passed values behind the scenes" field:
+      if (!mpValidationOptions[name].hideInput) {
+        const theseFields = AssociatedFields[name].fieldNames;
+        theseFields.forEach(fieldName => {
+          setValue(fieldName, '');
+        });
+      }
     }
 
     // Update the checkbox field itself


### PR DESCRIPTION
### PR description
#### What is it doing?
Adds in a check so that we're only clearing out MP field values when it's a scenario when the user is being shown the field, not a "pass the value behind the scenes, keep the field hidden" scenario.

#### Why is this required?
Bug raised

#### link to Jira ticket:
[Link to the Jira ticket.](https://comicrelief.atlassian.net/browse/ENG-2191)


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
