### PR TITLE
feat: add data-attribute to CardDS & SingleMsgDS for GA reasons

### DIFF
--- a/src/components/Molecules/CardDs/CardDs.js
+++ b/src/components/Molecules/CardDs/CardDs.js
@@ -119,6 +119,7 @@ const CardDs = ({
           tabIndex="-1"
           href={link}
           target={target}
+          data-cta-copy={linkLabel}
           {...rest}
         >
           {Media}

--- a/src/components/Molecules/CardDs/__snapshots__/CardDs.test.js.snap
+++ b/src/components/Molecules/CardDs/__snapshots__/CardDs.test.js.snap
@@ -189,6 +189,7 @@ exports[`renders correctly 1`] = `
   <a
     aria-hidden="true"
     className="c1"
+    data-cta-copy="Find out more"
     href="/home"
     tabIndex="-1"
     target="_blank"

--- a/src/components/Molecules/SingleMessageDS/SingleMessageDs.js
+++ b/src/components/Molecules/SingleMessageDS/SingleMessageDs.js
@@ -71,6 +71,7 @@ const SingleMessageDs = ({
           tabIndex="-1"
           href={youTubeId}
           target={target}
+          data-cta-copy={linkLabel}
           {...rest}
           onClick={e => { setIsOpen(true); e.preventDefault(); }}
         >

--- a/src/components/Molecules/SingleMessageDS/SingleMessageDs.js
+++ b/src/components/Molecules/SingleMessageDS/SingleMessageDs.js
@@ -31,7 +31,6 @@ const SingleMessageDs = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  // const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
 
   const Media = (
@@ -57,6 +56,7 @@ const SingleMessageDs = ({
           tabIndex="-1"
           href={link}
           target={target}
+          data-cta-copy={linkLabel}
           {...rest}
         >
           {Media}

--- a/src/components/Molecules/SingleMessageDS/__snapshots__/SingleMessageDs.test.js.snap
+++ b/src/components/Molecules/SingleMessageDS/__snapshots__/SingleMessageDs.test.js.snap
@@ -234,6 +234,7 @@ exports[`renders correctly 1`] = `
   <a
     aria-hidden="true"
     className="c1"
+    data-cta-copy="Check out the shop"
     href="/home"
     tabIndex="-1"
     target="_blank"


### PR DESCRIPTION

### PR description
#### What is it doing?
Just makes the CTA copy available to the GA when the user clicks on the img link, rather than the button; that way, Hiral and co. can better track the journey in relation to the content.

#### Why is this required?
Better GA insight

#### link to Jira ticket:
No ticket, just had a convo and it came up


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
