### PR TITLE
fix: handle autoplay muting Video banners

### DIFF
--- a/src/components/Molecules/VideoBanner/VideoBanner.js
+++ b/src/components/Molecules/VideoBanner/VideoBanner.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -12,6 +12,9 @@ const Video = styled.video.attrs(() => ({
 const VideoBanner = ({
   video, poster, controls, autoPlay, loop, muted, showPosterAfterPlaying
 }) => {
+  // Use the prop as our default
+  const [isMuted, setIsMuted] = useState(muted);
+
   const videoEl = useRef(null);
 
   const triggerPlay = () => {
@@ -22,6 +25,10 @@ const VideoBanner = ({
     // Trigger onload autoplay based on prop:
     if (autoPlay) {
       triggerPlay();
+
+      // As it's a Chrome requirement to mute any autoplay videos,
+      // update accordingly; see https://developer.chrome.com/blog/autoplay/
+      setIsMuted(true);
     }
 
     // And attach event listener based on prop:
@@ -40,7 +47,7 @@ const VideoBanner = ({
       ref={videoEl}
       controls={controls}
       loop={loop}
-      muted={muted}
+      muted={isMuted}
     >
       Your browser does not support video.
     </Video>

--- a/src/components/Molecules/VideoBanner/VideoBanner.js
+++ b/src/components/Molecules/VideoBanner/VideoBanner.js
@@ -38,7 +38,7 @@ const VideoBanner = ({
         videoEl.current.load();
       });
     }
-  });
+  }, [autoPlay, loop, showPosterAfterPlaying]);
 
   return (
     <Video

--- a/src/components/Molecules/VideoBanner/VideoBanner.js
+++ b/src/components/Molecules/VideoBanner/VideoBanner.js
@@ -24,11 +24,10 @@ const VideoBanner = ({
   useEffect(() => {
     // Trigger onload autoplay based on prop:
     if (autoPlay) {
-      triggerPlay();
-
       // As it's a Chrome requirement to mute any autoplay videos,
       // update accordingly; see https://developer.chrome.com/blog/autoplay/
       setIsMuted(true);
+      triggerPlay();
     }
 
     // And attach event listener based on prop:

--- a/src/components/Molecules/VideoBanner/VideoBanner.md
+++ b/src/components/Molecules/VideoBanner/VideoBanner.md
@@ -12,7 +12,7 @@ import poster from '../../../styleguide/assets/VideoBannerPosterImage.png';
 const src =
   'https://www.comicrelief.com/sites/default/files/downloads/Creativists_Logo_Web_small_V2_0.mp4';
 
-<VideoBanner poster={poster} video={src} loop={true} controls={true} autoPlay={true}
+<VideoBanner poster={poster} video={src} loop={true} controls={true} autoPlay={true} muted={false}
  />;
 ```
 


### PR DESCRIPTION

### PR description
#### What is it doing?
Forces muting of videos of autoplaying

#### Why is this required?
[Tell us why this is required from a business/product perspective.](https://developer.chrome.com/blog/autoplay/)

#### link to Jira ticket:
No ticket, just an bug thrown in CR PR


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
