### PR TITLE
fix: additional bg colour prop in ImpactSlider

### DIFF
--- a/src/components/Organisms/ImpactSlider/ImpactMoneybuys.style.js
+++ b/src/components/Organisms/ImpactSlider/ImpactMoneybuys.style.js
@@ -23,7 +23,7 @@ const Moneybuy = styled.div`
     height: auto;
     background-color: white;
     border-radius: 10px;
-    border: 1px solid ${props => props.theme.color('black')};;
+    border: 1px solid ${props => props.theme.color('black')};
     position: relative;
     flex-direction: row;
     align-items: center;

--- a/src/components/Organisms/ImpactSlider/ImpactSlider.js
+++ b/src/components/Organisms/ImpactSlider/ImpactSlider.js
@@ -10,8 +10,8 @@ import {
 } from './ImpactSlider.style';
 
 const ImpactSlider = ({
-  heading, cartID, donateLink, rowID, items, step,
-  max, opacityAnimation, children, defaultSliderValue
+  heading, cartID, donateLink, rowID, items, step, max,
+  backgroundColour, opacityAnimation, children, defaultSliderValue
 }) => {
   // Use the lowest possible amount as our default:
   const [currentAmount, setCurrentAmount] = useState(defaultSliderValue || step);
@@ -28,7 +28,7 @@ const ImpactSlider = ({
   };
 
   return (
-    <OuterWrapper>
+    <OuterWrapper backgroundColour={backgroundColour}>
       <InnerWrapper>
         <Text tag="h1" family="Anton" uppercase weight="normal" size="xl">{heading}</Text>
         <Copy>
@@ -67,7 +67,8 @@ const ImpactSlider = ({
 
 ImpactSlider.defaultProps = {
   opacityAnimation: false,
-  defaultSliderValue: null
+  defaultSliderValue: null,
+  backgroundColour: 'grey_extra_light'
 };
 
 ImpactSlider.propTypes = {
@@ -80,6 +81,7 @@ ImpactSlider.propTypes = {
   max: PropTypes.number.isRequired,
   defaultSliderValue: PropTypes.number,
   opacityAnimation: PropTypes.bool,
+  backgroundColour: PropTypes.string,
   items: PropTypes.arrayOf(
     PropTypes.shape({
       poundsPerItem: PropTypes.number.isRequired,

--- a/src/components/Organisms/ImpactSlider/ImpactSlider.md
+++ b/src/components/Organisms/ImpactSlider/ImpactSlider.md
@@ -34,6 +34,7 @@ import Text from '../../Atoms/Text/Text';
   step={5}
   max={100}
   defaultSliderValue={45}
+  backgroundColour="white"
   >
     <Text tag="p" color="black">
       Use this slider to see how your donation can make a difference to lives in the UK and around the globe this winter.

--- a/src/components/Organisms/ImpactSlider/ImpactSlider.style.js
+++ b/src/components/Organisms/ImpactSlider/ImpactSlider.style.js
@@ -6,7 +6,7 @@ const OuterWrapper = styled.div`
   position: relative;
   margin: 0 auto;
   max-width: 100%;
-  background-color: ${props => props.theme.color('grey_extra_light')};
+  background-color: ${props => props.theme.color(`${props.backgroundColour}`)};
   padding: 32px 16px;
 
   @media ${({ theme }) => theme.breakpoint('small')} {


### PR DESCRIPTION
### PR description
#### What is it doing?
Adds an additional bgcolour prop that I missed; the real thing will only allow white/grey in situ, but I've made this as flexible and future proof as possible

#### Why is this required?
Missed this requirement in the original PR

#### link to Jira ticket:
Nae ticket


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
