### PR TITLE
fix: remove inaccurate Donate widget button copy logic

### DIFF
--- a/src/components/Organisms/Donate/Donate.md
+++ b/src/components/Organisms/Donate/Donate.md
@@ -494,3 +494,31 @@ const desktopPictures = require('../../../styleguide/data/data').defaultData;
   subtitle="Please help us fund life-changing projects in the UK and around the world."
 />;
 ```
+
+## Monthly ONLY, no moneybuys
+
+```js
+import data from './dev-data/data-monthly';
+const mobilePictures = require('../../../styleguide/data/data').mobileImages;
+const desktopPictures = require('../../../styleguide/data/data').defaultData;
+
+<Donate
+  alt="Background image"
+  mobileBackgroundColor="deep_violet_dark"
+  desktopOverlayColor="red"
+  submitButtonColor="blue_dark"
+  formAlignRight={true}
+  imageLow={desktopPictures.imageLow}
+  images={desktopPictures.images}
+  mobileImageLow={mobilePictures.imageLow}
+  mobileImages={mobilePictures.images}
+  data={data}
+  mbshipID="mship-15"
+  donateLink="https://donation.comicrelief.com/"
+  clientID="donate"
+  cartID="default-comicrelief"
+  title="Donate Now"
+  subtitle="Please help us fund life-changing projects in the UK and around the world."
+  noMoneyBuys
+/>;
+```

--- a/src/components/Organisms/Donate/Form/Form.js
+++ b/src/components/Organisms/Donate/Form/Form.js
@@ -305,25 +305,13 @@ const Signup = ({
           </p>
           )}
 
-          {noMoneyBuys ? (
-            <Button
-              type="submit"
-              color={submitButtonColor}
-            >
-              {errorMsg
-                ? 'Donate'
-                : `Donate £${amountDonate}`}
-            </Button>
-          ) : (
-            <Button
-              type="submit"
-              color={submitButtonColor}
-              ref={buttonRef}
-            >
-              {renderButtonText()}
-            </Button>
-
-          )}
+          <Button
+            type="submit"
+            color={submitButtonColor}
+            ref={buttonRef}
+          >
+            {renderButtonText()}
+          </Button>
 
         </OuterFieldset>
       </Form>

--- a/src/components/Organisms/Donate/__snapshots__/Donate.test.js.snap
+++ b/src/components/Organisms/Donate/__snapshots__/Donate.test.js.snap
@@ -640,7 +640,7 @@ exports[`"Single Giving, No Money Buys, with overridden manual input value" rend
             color="red"
             type="submit"
           >
-            Donate £345.67
+            Donate £345.67 now
           </button>
         </fieldset>
       </form>
@@ -2456,7 +2456,7 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
             color="red"
             type="submit"
           >
-            Donate £10
+            Donate £10 monthly
           </button>
         </fieldset>
       </form>


### PR DESCRIPTION
### PR description
#### What is it doing?
Removes inaccurate button logic that resulted in button copy that didn't actually _mention_ 'monthly' for "no moneybuy" Monthly donate widgets

#### Why is this required?
To fix some terrible UX
#### link to Jira ticket:
Piggybacking off https://github.com/comicrelief/comicrelief-contentful/pull/1437 for https://comicrelief.atlassian.net/browse/ENG-2


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
