### PR TITLE
feat: Single Message padding options on LG

### DIFF
--- a/src/components/Molecules/SingleMessage/SingleMessage.js
+++ b/src/components/Molecules/SingleMessage/SingleMessage.js
@@ -30,7 +30,8 @@ const SingleMessage = ({
   fullImage,
   vhFull,
   videoID,
-  landscapeVideo
+  landscapeVideo,
+  paddingOption
 }) => {
   const hasImage = imageSet || false;
   const doubleImage = (imageSet || image) && (imageSet2 || image2);
@@ -207,6 +208,7 @@ const SingleMessage = ({
               copyFirst={copyFirst}
               hasVideo={hasVideo}
               vhFull={vhFull}
+              paddingOption={paddingOption}
             >
               {children}
             </Copy>
@@ -234,7 +236,8 @@ SingleMessage.propTypes = {
   /** Image will be the height of the viewport */
   vhFull: PropTypes.bool,
   videoID: PropTypes.string,
-  landscapeVideo: PropTypes.bool
+  landscapeVideo: PropTypes.bool,
+  paddingOption: PropTypes.string
 };
 
 SingleMessage.defaultProps = {
@@ -251,7 +254,8 @@ SingleMessage.defaultProps = {
   children: null,
   vhFull: false,
   videoID: null,
-  landscapeVideo: false
+  landscapeVideo: false,
+  paddingOption: null
 };
 
 export default SingleMessage;

--- a/src/components/Molecules/SingleMessage/SingleMessage.md
+++ b/src/components/Molecules/SingleMessage/SingleMessage.md
@@ -84,6 +84,59 @@ import Text from '../../Atoms/Text/Text';
 </SingleMessage>;
 ```
 
+Single Message with no Image - padding unmodified
+
+```js
+import Text from '../../Atoms/Text/Text';
+
+<SingleMessage backgroundColor="purple_dark" copyFirst={false} paddingOption="both_on">
+  <Text tag="p" color="white" size="xxl">
+    “The creativity that goes into helping people have a better life is
+    extraordinary.”
+  </Text>
+</SingleMessage>;
+```
+
+Single Message with no Image - no bottom padding
+
+```js
+import Text from '../../Atoms/Text/Text';
+
+<SingleMessage backgroundColor="purple_dark" copyFirst={false} paddingOption="lower_off">
+  <Text tag="p" color="white" size="xxl">
+    “The creativity that goes into helping people have a better life is
+    extraordinary.”
+  </Text>
+</SingleMessage>;
+```
+
+
+Single Message with no Image - no top padding
+
+```js
+import Text from '../../Atoms/Text/Text';
+
+<SingleMessage backgroundColor="purple_dark" copyFirst={false} paddingOption="upper_off">
+  <Text tag="p" color="white" size="xxl">
+    “The creativity that goes into helping people have a better life is
+    extraordinary.”
+  </Text>
+</SingleMessage>;
+```
+
+Single Message with no Image - no top and bottom padding 
+
+```js
+import Text from '../../Atoms/Text/Text';
+
+<SingleMessage backgroundColor="purple_dark" copyFirst={false} paddingOption="both_off">
+  <Text tag="p" color="white" size="xxl">
+    “The creativity that goes into helping people have a better life is
+    extraordinary.”
+  </Text>
+</SingleMessage>;
+```
+
 Single Message vertical height 100%
 
 ```js

--- a/src/components/Molecules/SingleMessage/SingleMessage.style.js
+++ b/src/components/Molecules/SingleMessage/SingleMessage.style.js
@@ -5,6 +5,7 @@ import zIndex from '../../../theme/shared/zIndex';
 import playIcon from './assets/video--play-icon.svg';
 import playIconHover from './assets/video--play-icon__hover.svg';
 import loadingIcon from './assets/loader.svg';
+import handlePadding from '../../../utils/_utils';
 
 const Container = styled.div`
   display: flex;
@@ -31,6 +32,7 @@ const Copy = styled.div`
   ${zIndex('low')};
   ${({ hasVideo, fullImage }) => (hasVideo === true && fullImage === true ? 'display: none;' : null)};
   padding: ${spacing('l')};
+  
   ${media('small')} {
     ${({ vhFull, fullImage }) => (vhFull || fullImage
     ? 'min-height: calc(100vh - 5.625rem); flex-direction: column; justify-content: center;'
@@ -44,6 +46,7 @@ const Copy = styled.div`
     justify-content: center;
     padding: ${spacing('xl')};
   }
+
   ${props => props.fullImage
     && css`
       ${media('small')} {
@@ -52,17 +55,13 @@ const Copy = styled.div`
         right: 0;
         top: 50%;
         transform: translateY(-50%);
-        ${props.copyFirst
-    ? css`
-              left: 0;
-            `
-    : null}
+        ${props.copyFirst ? css`left: 0;` : null}
         width: 50%;
       }
     `};
+
   ${props => (props.hasImage
-    ? css`
-          @media ${({ theme }) => theme.breakpoint('small')} {
+    ? css`@media ${({ theme }) => theme.breakpoint('small')} {
             width: 50%;
           }
         `
@@ -75,6 +74,10 @@ const Copy = styled.div`
           margin: auto;
           padding: ${spacing('md')};
         `)};
+
+  ${media('medium')} {
+    ${({ paddingOption }) => handlePadding(paddingOption)};
+  }      
 `;
 
 const Media = styled.div`

--- a/src/components/Molecules/SingleMessage/__snapshots__/SingleMessage.test.js.snap
+++ b/src/components/Molecules/SingleMessage/__snapshots__/SingleMessage.test.js.snap
@@ -104,6 +104,10 @@ exports[`renders Single Message with 100% vertical height image correctly 1`] = 
   }
 }
 
+@media (min-width:1024px) {
+
+}
+
 @media (min-width:740px) {
   .c1 {
     height: auto;
@@ -312,6 +316,10 @@ exports[`renders Single Message with Image correctly 1`] = `
   }
 }
 
+@media (min-width:1024px) {
+
+}
+
 @media (min-width:740px) {
   .c1 {
     height: auto;
@@ -498,11 +506,19 @@ exports[`renders Single Message with double image correctly 1`] = `
   }
 }
 
+@media (min-width:1024px) {
+
+}
+
 @media (min-width:740px) {
 
 }
 
 @media (min-width:740px) {
+
+}
+
+@media (min-width:1024px) {
 
 }
 
@@ -766,6 +782,10 @@ exports[`renders Single Message with full width correctly 1`] = `
   }
 }
 
+@media (min-width:1024px) {
+
+}
+
 @media (min-width:740px) {
   .c1 {
     height: auto;
@@ -920,6 +940,10 @@ exports[`renders Single Message with full width image and no text correctly 1`] 
 
 }
 
+@media (min-width:1024px) {
+
+}
+
 @media (min-width:740px) {
   .c1 {
     height: auto;
@@ -1052,11 +1076,19 @@ exports[`renders Single Message with no Image correctly 1`] = `
   }
 }
 
+@media (min-width:1024px) {
+
+}
+
 @media (min-width:740px) {
 
 }
 
 @media (min-width:740px) {
+
+}
+
+@media (min-width:1024px) {
 
 }
 


### PR DESCRIPTION
### PR description
#### What is it doing?
Uses the same padding logic from the CardsDS, Cards and Donate paragraph work to add the same options to Single Msg component (on LG only)

#### Why is this required?
Flexibility and improved aesthetics for heavy bits of content

#### link to Jira ticket:
comicrelief.atlassian.net/browse/ENG-3087


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
