### PR TITLE
feat: CRcom text colour rule tweak

### DIFF
--- a/src/components/Atoms/Button/Button.js
+++ b/src/components/Atoms/Button/Button.js
@@ -23,6 +23,7 @@ const StyledButton = styled.button`
   border: none;
   cursor: pointer;
   color: ${({ backgroundColor }) => getContrastColor(backgroundColor)};
+  border: 1px solid ${({ backgroundColor }) => getContrastColor(backgroundColor)};
   background-color: ${({ backgroundColor, theme }) => theme.buttonColors(backgroundColor || 'red')};
   > a {
     text-decoration: none;

--- a/src/components/Atoms/Button/Button.js
+++ b/src/components/Atoms/Button/Button.js
@@ -29,7 +29,7 @@ const StyledButton = styled.button`
     text-decoration: none;
     color: inherit;
   }
-  ${({ color, theme }) => (color ? theme.buttonColors(color) : theme.buttonColors('red'))};
+  // ${({ color, theme }) => (color ? theme.buttonColors(color) : theme.buttonColors('red'))};
   @media ${({ theme }) => theme.breakpoint('small')} {
     width: auto;
   }

--- a/src/components/Atoms/Button/Button.js
+++ b/src/components/Atoms/Button/Button.js
@@ -4,6 +4,9 @@ import styled from 'styled-components';
 import spacing from '../../../theme/shared/spacing';
 import media from '../../../theme/shared/breakpoint';
 
+// Function to decide contrast color based on background color
+const getContrastColor = backgroundColor => (backgroundColor === 'red' ? 'white' : 'black');
+
 const StyledButton = styled.button`
   display: inline-flex;
   position: relative;
@@ -19,8 +22,11 @@ const StyledButton = styled.button`
   align-items: center;
   border: none;
   cursor: pointer;
+  color: ${({ backgroundColor }) => getContrastColor(backgroundColor)};
+  background-color: ${({ backgroundColor, theme }) => theme.buttonColors(backgroundColor || 'red')};
   > a {
     text-decoration: none;
+    color: inherit;
   }
   ${({ color, theme }) => (color ? theme.buttonColors(color) : theme.buttonColors('red'))};
   @media ${({ theme }) => theme.breakpoint('small')} {
@@ -34,20 +40,31 @@ const StyledButton = styled.button`
   }
 `;
 
-const Button = React.forwardRef(({ children, wrapper, ...rest }, ref) => (
-  <StyledButton {...rest} as={wrapper ? 'span' : 'button'} ref={ref}>
-    {children}
-  </StyledButton>
-));
+const Button = React.forwardRef(
+  ({
+    children, backgroundColor = 'red', wrapper, ...rest
+  }, ref) => (
+    <StyledButton
+      {...rest}
+      backgroundColor={backgroundColor}
+      as={wrapper ? 'span' : 'button'}
+      ref={ref}
+    >
+      {children}
+    </StyledButton>
+  )
+);
 
 Button.propTypes = {
   /** Buttons as span */
   wrapper: PropTypes.bool,
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  backgroundColor: PropTypes.string
 };
 
 Button.defaultProps = {
-  wrapper: false
+  wrapper: false,
+  backgroundColor: 'red'
 };
 
 export default Button;

--- a/src/components/Atoms/Button/Button.js
+++ b/src/components/Atoms/Button/Button.js
@@ -5,7 +5,12 @@ import spacing from '../../../theme/shared/spacing';
 import media from '../../../theme/shared/breakpoint';
 
 // Function to decide contrast color based on background color
-const getContrastColor = backgroundColor => (backgroundColor === 'red' ? 'white' : 'black');
+const getContrastColor = (backgroundColor, theme) => {
+  if (backgroundColor === theme.red) {
+    return theme.white; // Use white text for red background
+  }
+  return theme.black; // Default text color is black
+};
 
 const StyledButton = styled.button`
   display: inline-flex;
@@ -22,9 +27,8 @@ const StyledButton = styled.button`
   align-items: center;
   border: none;
   cursor: pointer;
-  color: ${({ backgroundColor }) => getContrastColor(backgroundColor)};
-  border: 1px solid ${({ backgroundColor }) => getContrastColor(backgroundColor)};
-  background-color: ${({ backgroundColor, theme }) => theme.buttonColors(backgroundColor || 'red')};
+  color: ${({ backgroundColor, theme }) => getContrastColor(backgroundColor, theme)};
+  background-color: ${({ backgroundColor, theme }) => theme.buttonColors(backgroundColor)};
   > a {
     text-decoration: none;
     color: inherit;
@@ -43,7 +47,7 @@ const StyledButton = styled.button`
 
 const Button = React.forwardRef(
   ({
-    children, backgroundColor = 'red', wrapper, ...rest
+    children, backgroundColor, wrapper, ...rest
   }, ref) => (
     <StyledButton
       {...rest}

--- a/src/components/Atoms/Button/Button.test.js
+++ b/src/components/Atoms/Button/Button.test.js
@@ -39,8 +39,6 @@ it("renders a standard styled link correctly", () => {
       border: 1px solid white;
       background-color: background-color:#E52630;
       color: #FFFFFF;
-      background-color: #E52630;
-      color: #FFFFFF;
     }
 
     .c0:hover {
@@ -52,11 +50,6 @@ it("renders a standard styled link correctly", () => {
       -webkit-text-decoration: none;
       text-decoration: none;
       color: inherit;
-    }
-
-    .c0:hover {
-      background-color: #890B11;
-      color: #FFFFFF;
     }
 
     .c0 (min-width:1024px) {

--- a/src/components/Atoms/Button/Button.test.js
+++ b/src/components/Atoms/Button/Button.test.js
@@ -35,8 +35,6 @@ it("renders a standard styled link correctly", () => {
       align-items: center;
       border: none;
       cursor: pointer;
-      color: white;
-      border: 1px solid white;
       background-color: background-color:#E52630;
       color: #FFFFFF;
     }

--- a/src/components/Atoms/Button/Button.test.js
+++ b/src/components/Atoms/Button/Button.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
-import Button from './Button';
+import React from "react";
+import "jest-styled-components";
+import renderWithTheme from "../../../hoc/shallowWithTheme";
+import Button from "./Button";
 
-it('renders a standard styled link correctly', () => {
+it("renders a standard styled link correctly", () => {
   const tree = renderWithTheme(
     <Button type="submit">A standard link</Button>
   ).toJSON();
@@ -35,13 +35,22 @@ it('renders a standard styled link correctly', () => {
       align-items: center;
       border: none;
       cursor: pointer;
+      color: white;
+      background-color: background-color:#E52630;
+      color: #FFFFFF;
       background-color: #E52630;
+      color: #FFFFFF;
+    }
+
+    .c0:hover {
+      background-color: #890B11;
       color: #FFFFFF;
     }
 
     .c0 > a {
       -webkit-text-decoration: none;
       text-decoration: none;
+      color: inherit;
     }
 
     .c0:hover {

--- a/src/components/Atoms/Button/Button.test.js
+++ b/src/components/Atoms/Button/Button.test.js
@@ -36,6 +36,7 @@ it("renders a standard styled link correctly", () => {
       border: none;
       cursor: pointer;
       color: white;
+      border: 1px solid white;
       background-color: background-color:#E52630;
       color: #FFFFFF;
       background-color: #E52630;

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -60,8 +60,6 @@ exports[`renders correctly 1`] = `
   border: 1px solid white;
   background-color: background-color:#E52630;
   color: #FFFFFF;
-  background-color: #E52630;
-  color: #FFFFFF;
 }
 
 .c15:hover {
@@ -73,11 +71,6 @@ exports[`renders correctly 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: inherit;
-}
-
-.c15:hover {
-  background-color: #890B11;
-  color: #FFFFFF;
 }
 
 .c15 (min-width:1024px) {

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -57,6 +57,7 @@ exports[`renders correctly 1`] = `
   border: none;
   cursor: pointer;
   color: white;
+  border: 1px solid white;
   background-color: background-color:#E52630;
   color: #FFFFFF;
   background-color: #E52630;

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -56,8 +56,6 @@ exports[`renders correctly 1`] = `
   align-items: center;
   border: none;
   cursor: pointer;
-  color: white;
-  border: 1px solid white;
   background-color: background-color:#E52630;
   color: #FFFFFF;
 }

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -56,13 +56,22 @@ exports[`renders correctly 1`] = `
   align-items: center;
   border: none;
   cursor: pointer;
+  color: white;
+  background-color: background-color:#E52630;
+  color: #FFFFFF;
   background-color: #E52630;
+  color: #FFFFFF;
+}
+
+.c15:hover {
+  background-color: #890B11;
   color: #FFFFFF;
 }
 
 .c15 > a {
   -webkit-text-decoration: none;
   text-decoration: none;
+  color: inherit;
 }
 
 .c15:hover {


### PR DESCRIPTION
**PR description**

**What is it doing?**

Fixed - Promo with mobile background colour set to red will also use a red CTA, which is not visible

**Why is this required?**

As per Curtis it's ideal so we can have more flexibility in page designs

**link to Jira ticket:**
[ENG-2979]

### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-2979]: https://comicrelief.atlassian.net/browse/ENG-2979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ