### PR TITLE
chore: Move dependencies to devDependencies (to reduce library weight)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,10 @@ module.exports = function (api) {
     api.cache(true);
 
     const presets = [ ["react-app", { "absoluteRuntime": false }] ];
-    const plugins = [ ["babel-plugin-styled-components"] ];
+    const plugins = [
+        ["babel-plugin-styled-components"],
+        ["import", { "libraryName": "lodash", "libraryDirectory": "", "camel2DashComponentName": false }]
+    ];
 
     return {
         presets,

--- a/package.json
+++ b/package.json
@@ -21,13 +21,8 @@
     "url": "https://github.com/comicrelief/component-library.git"
   },
   "dependencies": {
-    "@babel/cli": "^7.21.5",
-    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@hookform/resolvers": "^1.3.4",
-    "@playwright/test": "^1.38.1",
     "axios": "^0.21.1",
-    "ejs": "^3.1.9",
-    "jest-styled-components": "^7.1.1",
     "lazysizes": "^5.3.2",
     "lodash": "^4.17.11",
     "moment": "^2.29.4",
@@ -41,9 +36,7 @@
     "react-modal": "^3.16.1",
     "react-range-slider-input": "^3.0.7",
     "react-responsive": "^9.0.2",
-    "react-scripts": "4.0.3",
     "react-spinners": "^0.11.0",
-    "react-styleguidist": "^11.1.7",
     "react-test-renderer": "^17.0.2",
     "react-uid": "^2.3.3",
     "styled-components": "^5.3.11",
@@ -80,7 +73,11 @@
     ]
   },
   "devDependencies": {
+    "@babel/cli": "^7.21.5",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "@playwright/test": "^1.38.1",
     "cross-env": "^7.0.3",
+    "ejs": "^3.1.9",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-plugin-import": "^2.27.5",
@@ -88,8 +85,11 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^26.1.0",
+    "jest-styled-components": "^7.1.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",
+    "react-scripts": "4.0.3",
+    "react-styleguidist": "^11.1.7",
     "semantic-release": "^17.4.6",
     "start-server-and-test": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@babel/cli": "^7.21.5",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@playwright/test": "^1.38.1",
+    "babel-plugin-import": "^1.13.8",
     "cross-env": "^7.0.3",
     "ejs": "^3.1.9",
     "eslint": "^7.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3340,6 +3340,13 @@ babel-loader@8.1.0:
     pify "^4.0.1"
     schema-utils "^2.6.5"
 
+babel-plugin-import@^1.13.8:
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-import/-/babel-plugin-import-1.13.8.tgz#782c517f6bbf2de3b1f75aaafd6d20a491c4878c"
+  integrity sha512-36babpjra5m3gca44V6tSTomeBlPA7cHUynrE2WiQIm3rEGD9xy28MKsx5IdO45EbnpJY7Jrgd00C6Dwt/l/2Q==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+
 babel-plugin-istanbul@^6.0.0:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"


### PR DESCRIPTION
### PR Titles
#### To pass testing pipeline, these need to follow Conventional Commits spec:
https://www.conventionalcommits.org/en/v1.0.0/
e.g.
`feat: create NewForm component`
or
`fix: update broken link in NewForm component`


### PR description
#### What is it doing?
Move `dependencies` that don't need to be published (i.e. supporting dependencies, those not referenced in the codebase) to `devDependencies`.

#### Why is this required?
Reducing the list of `dependencies` reduces the weight of the library, improving performance.

#### link to Jira ticket:
Add a link to the Jira ticket.


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
