### PR TITLE
fix: Tweak build step after deps change

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "test:unit:update": "yarn jest -u",
     "styleguide": "cross-env FAST_REFRESH=false styleguidist server",
     "styleguide:build": "styleguidist build",
-    "postinstall": "yarn run build",
     "test:e2e": "playwright test --project=chromium",
     "test:e2e--h": "playwright test --project=chromium --headed",
     "test:e2e:ci": "NODE_ENV=development; start-server-and-test styleguide http://localhost:6060 test:e2e",


### PR DESCRIPTION
### PR Titles
#### To pass testing pipeline, these need to follow Conventional Commits spec:
https://www.conventionalcommits.org/en/v1.0.0/
e.g.
`feat: create NewForm component`
or
`fix: update broken link in NewForm component`


### PR description
#### What is it doing?
Remove the `postinstall` step as its unnecessary (the `dist` folder is packaged with the build) and it will fail on environments where the `devDependencies` haven't been installed (i.e. anywhere where `@comicrelief/compontent-library` is a dependency).

#### Why is this required?
See above

#### link to Jira ticket:
Add a link to the Jira ticket.


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
