### PR TITLE
fix: Move "react-test-renderer" to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "react-range-slider-input": "^3.0.7",
     "react-responsive": "^9.0.2",
     "react-spinners": "^0.11.0",
-    "react-test-renderer": "^17.0.2",
     "react-uid": "^2.3.3",
     "styled-components": "^5.3.11",
     "youtube-player": "^5.6.0",
@@ -90,6 +89,7 @@
     "prettier": "^2.8.8",
     "react-scripts": "4.0.3",
     "react-styleguidist": "^11.1.7",
+    "react-test-renderer": "^17.0.2",
     "semantic-release": "^17.4.6",
     "start-server-and-test": "^2.0.0"
   }

--- a/src/components/Atoms/Button/Button.test.js
+++ b/src/components/Atoms/Button/Button.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import Button from "./Button";
 
 it("renders a standard styled link correctly", () => {

--- a/src/components/Atoms/Checkbox/Checkbox.test.js
+++ b/src/components/Atoms/Checkbox/Checkbox.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Checkbox from './Checkbox';
 
 it('renders correctly', () => {

--- a/src/components/Atoms/ErrorText/ErrorText.test.js
+++ b/src/components/Atoms/ErrorText/ErrorText.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import 'jest-styled-components';
 
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import ErrorText from './ErrorText';
 
 it('renders correctly', () => {

--- a/src/components/Atoms/Input/input.test.js
+++ b/src/components/Atoms/Input/input.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Input from './Input';
 
 it('renders correctly', () => {

--- a/src/components/Atoms/Link/Link.test.js
+++ b/src/components/Atoms/Link/Link.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import Link from "./Link";
 import { Internal } from "../Icons/index";
 

--- a/src/components/Atoms/Logo/Logo.test.js
+++ b/src/components/Atoms/Logo/Logo.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import Logo from "./Logo";
 
 it("renders correctly", () => {

--- a/src/components/Atoms/Pagination/Pagination.test.js
+++ b/src/components/Atoms/Pagination/Pagination.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Pagination from './Pagination';
 
 it('renders correctly in minimalist form', () => {

--- a/src/components/Atoms/Picture/Picture.test.js
+++ b/src/components/Atoms/Picture/Picture.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import Picture from "./Picture";
 import { defaultData } from "../../../styleguide/data/data";
 it("renders correctly", () => {

--- a/src/components/Atoms/RadioButton/RadioButton.test.js
+++ b/src/components/Atoms/RadioButton/RadioButton.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import RadioButton from './RadioButton';
 
 it('renders correctly', () => {

--- a/src/components/Atoms/RichText/RichText.test.js
+++ b/src/components/Atoms/RichText/RichText.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import RichText from './RichText';
 
 const htmlContent = "<p>Here's some copy</p><span>More copy</span>";

--- a/src/components/Atoms/Select/Select.test.js
+++ b/src/components/Atoms/Select/Select.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Select from './Select';
 
 it('renders correctly', () => {

--- a/src/components/Atoms/SocialIcons/SocialIcons.test.js
+++ b/src/components/Atoms/SocialIcons/SocialIcons.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import SocialIcons from './SocialIcons';
 
 it('renders correctly with Comic Relief links', () => {

--- a/src/components/Atoms/Text/Text.test.js
+++ b/src/components/Atoms/Text/Text.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Text from './Text';
 
 it('renders high heading correctly', () => {

--- a/src/components/Atoms/TextArea/TextArea.test.js
+++ b/src/components/Atoms/TextArea/TextArea.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import TextArea from './TextArea';
 
 it('renders correctly', () => {

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.test.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import 'jest-styled-components';
 
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import TextInputWithDropdown from './TextInputWithDropdown';
 import { Dropdown, Container } from './TextInputWithDropdown.style';
 

--- a/src/components/Molecules/Accordion/Accordion.test.js
+++ b/src/components/Molecules/Accordion/Accordion.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Accordion from './Accordion';
 import Text from '../../Atoms/Text/Text';
 

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import ArticleTeaser from "./ArticleTeaser";
 import { defaultData } from "../../../styleguide/data/data";
 it("renders article teaser correctly", () => {

--- a/src/components/Molecules/Banner/Banner.test.js
+++ b/src/components/Molecules/Banner/Banner.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Banner from './Banner';
 import Text from '../../Atoms/Text/Text';
 

--- a/src/components/Molecules/Box/Box.test.js
+++ b/src/components/Molecules/Box/Box.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Box from './Box';
 import { defaultData } from '../../../styleguide/data/data';
 it('renders correctly', () => {

--- a/src/components/Molecules/Card/Card.test.js
+++ b/src/components/Molecules/Card/Card.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Card from './Card';
 import { defaultData } from '../../../styleguide/data/data';
 it('renders correctly', () => {

--- a/src/components/Molecules/CardDs/CardDs.test.js
+++ b/src/components/Molecules/CardDs/CardDs.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import CardDs from './CardDs';
 import { defaultData }  from '../../../styleguide/data/data';import { Internal } from '../../Atoms/Icons/index';
 

--- a/src/components/Molecules/Chip/Chip.test.js
+++ b/src/components/Molecules/Chip/Chip.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import Chip from "./Chip";
 
 it("renders article teaser correctly", () => {

--- a/src/components/Molecules/Descriptor/Descriptor.test.js
+++ b/src/components/Molecules/Descriptor/Descriptor.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Descriptor from './Descriptor';
 
 it('renders article teaser correctly', () => {

--- a/src/components/Molecules/DoubleCopy/DoubleCopy.test.js
+++ b/src/components/Molecules/DoubleCopy/DoubleCopy.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import 'jest-styled-components';
 
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import DoubleCopy from './DoubleCopy';
 import RichText from '../../Atoms/RichText/RichText';
 

--- a/src/components/Molecules/InfoBanner/InfoBanner.test.js
+++ b/src/components/Molecules/InfoBanner/InfoBanner.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import InfoBanner from './InfoBanner';
 
 it('renders correctly', () => {

--- a/src/components/Molecules/PartnerLink/PartnerLink.test.js
+++ b/src/components/Molecules/PartnerLink/PartnerLink.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "jest-styled-components";
 
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import PartnerLink from "./PartnerLink";
 import Picture from "../../Atoms/Picture/Picture";
 import { defaultData } from "../../../styleguide/data/data";

--- a/src/components/Molecules/Promo/Promo.test.js
+++ b/src/components/Molecules/Promo/Promo.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Promo from './Promo';
 import Text from '../../Atoms/Text/Text';
 import Link from '../../Atoms/Link/Link';

--- a/src/components/Molecules/SchoolLookup/SchoolLookup.test.js
+++ b/src/components/Molecules/SchoolLookup/SchoolLookup.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import 'jest-styled-components';
 
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import SchoolLookup from './SchoolLookup';
 
 it('renders correctly', () => {

--- a/src/components/Molecules/SearchInput/SearchInput.test.js
+++ b/src/components/Molecules/SearchInput/SearchInput.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import SearchInput from './SearchInput';
 
 it('renders correctly', () => {

--- a/src/components/Molecules/SearchResult/SearchResult.test.js
+++ b/src/components/Molecules/SearchResult/SearchResult.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import SearchResult from './SearchResult';
 import { defaultData } from '../../../styleguide/data/data';
 

--- a/src/components/Molecules/ShareButton/ShareButton.test.js
+++ b/src/components/Molecules/ShareButton/ShareButton.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import ShareButton from './ShareButton';
 
 it('renders correctly', () => {

--- a/src/components/Molecules/SingleMessage/SingleMessage.test.js
+++ b/src/components/Molecules/SingleMessage/SingleMessage.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import SingleMessage from './SingleMessage';
 import { defaultData }  from '../../../styleguide/data/data';import Text from '../../Atoms/Text/Text';
 import Link from '../../Atoms/Link/Link';

--- a/src/components/Molecules/SingleMessageDS/SingleMessageDs.test.js
+++ b/src/components/Molecules/SingleMessageDS/SingleMessageDs.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import SingleMessageDs from './SingleMessageDs';
 import Text from '../../Atoms/Text/Text';
 import Download from '../../Atoms/Icons/Download';

--- a/src/components/Molecules/Typeahead/Typeahead.test.js
+++ b/src/components/Molecules/Typeahead/Typeahead.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import 'jest-styled-components';
 import axios from 'axios';
 
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Typeahead from './Typeahead';
 
 const schoolsLookup = async query => {

--- a/src/components/Molecules/VideoBanner/VideoBanner.test.js
+++ b/src/components/Molecules/VideoBanner/VideoBanner.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "jest-styled-components";
 
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import VideoBanner from "./VideoBanner";
 import poster from "../../../styleguide/assets/VideoBannerPosterImage.png";
 

--- a/src/components/Organisms/CookieBanner/CookieBanner.test.js
+++ b/src/components/Organisms/CookieBanner/CookieBanner.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import CookieBanner from "./CookieBanner";
 
 it("renders correctly", () => {

--- a/src/components/Organisms/Donate/Donate.test.js
+++ b/src/components/Organisms/Donate/Donate.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Donate from './Donate';
 import data from './dev-data/data';
 import singleData from './dev-data/data-single';

--- a/src/components/Organisms/EmailSignUp/EmailSignUp.test.js
+++ b/src/components/Organisms/EmailSignUp/EmailSignUp.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import "jest-styled-components";
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import { EmailSignUp, validationSchema } from "./_EmailSignUp";
 import RichText from "../../Atoms/RichText/RichText";
 import { useForm, FormProvider } from "react-hook-form";

--- a/src/components/Organisms/Footer/Footer.test.js
+++ b/src/components/Organisms/Footer/Footer.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-wrap-multilines */
 import React from 'react';
 import 'jest-styled-components';
-import renderWithTheme from '../../../hoc/shallowWithTheme';
+import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import Footer from './Footer';
 
 import data from './data/data';

--- a/src/components/Organisms/Header/header.test.js
+++ b/src/components/Organisms/Header/header.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-wrap-multilines */
 // import React from 'react';
 import 'jest-styled-components';
-// import renderWithTheme from '../../../hoc/shallowWithTheme';
+// import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 // import Header from './Header';
 
 // import data from './data/data';

--- a/src/components/Organisms/Membership/Membership.test.js
+++ b/src/components/Organisms/Membership/Membership.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "jest-styled-components";
 
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import Membership from "./Membership";
 import { defaultData } from "../../../styleguide/data/data";
 import data from "./dev-data/data";

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.test.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "jest-styled-components";
 
-import renderWithTheme from "../../../hoc/shallowWithTheme";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import WYMDCarousel from "./WYMDCarousel";
 const { carouselItemsComplete } = require("../../../styleguide/data/data");
 

--- a/tests/hoc/shallowWithTheme.js
+++ b/tests/hoc/shallowWithTheme.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { crTheme } from '../index';
-import ThemeProvider from '../theme/ThemeProvider';
+
+import { crTheme } from '../../src/index';
+import ThemeProvider from '../../src/theme/ThemeProvider';
 
 export default function renderWithTheme(component) {
   return renderer.create(


### PR DESCRIPTION
### PR Titles
#### To pass testing pipeline, these need to follow Conventional Commits spec:
https://www.conventionalcommits.org/en/v1.0.0/
e.g.
`feat: create NewForm component`
or
`fix: update broken link in NewForm component`


### PR description
#### What is it doing?
Move `react-test-render` to be a `devDependency` to reduce library weight.

#### Why is this required?
Reduces library weight for apps that include it.

#### link to Jira ticket:
[DF-56]


### Quick Checklist:
- [ ] My PR title follows the Conventional Commit spec.

- [ ] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[DF-56]: https://comicrelief.atlassian.net/browse/DF-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ