### PR TITLE
feat: Convert defaultProps to argument defaults

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
       "exceptions": [""]
     }],
     "arrow-parens": [2, "as-needed", { "requireForBlockBody": false }],
+    "react/require-default-props": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "react/jsx-filename-extension": "off",

--- a/src/components/Atoms/Button/Button.js
+++ b/src/components/Atoms/Button/Button.js
@@ -33,7 +33,7 @@ const StyledButton = styled.button`
   }
 `;
 
-const Button = React.forwardRef(({ children, wrapper, ...rest }, ref) => (
+const Button = React.forwardRef(({ children, wrapper = false, ...rest }, ref) => (
   <StyledButton {...rest} as={wrapper ? 'span' : 'button'} ref={ref}>
     {children}
   </StyledButton>
@@ -41,12 +41,8 @@ const Button = React.forwardRef(({ children, wrapper, ...rest }, ref) => (
 
 Button.propTypes = {
   /** Buttons as span */
-  wrapper: PropTypes.bool,
-  children: PropTypes.node.isRequired
-};
-
-Button.defaultProps = {
-  wrapper: false
+  children: PropTypes.node.isRequired,
+  wrapper: PropTypes.bool
 };
 
 export default Button;

--- a/src/components/Atoms/Button/Button.js
+++ b/src/components/Atoms/Button/Button.js
@@ -40,9 +40,8 @@ const Button = React.forwardRef(({ children, wrapper = false, ...rest }, ref) =>
 ));
 
 Button.propTypes = {
-  /** Buttons as span */
   children: PropTypes.node.isRequired,
-  wrapper: PropTypes.bool
+  wrapper: PropTypes.bool // Buttons as span
 };
 
 export default Button;

--- a/src/components/Atoms/ButtonWithStates/ButtonWithStates.js
+++ b/src/components/Atoms/ButtonWithStates/ButtonWithStates.js
@@ -19,7 +19,7 @@ const LoaderContainer = styled.div`${({ withMargin }) => (withMargin ? `
 
 // A button with loading and disabled states.
 const ButtonWithStates = React.forwardRef(({
-  children, loadingText, loading, disabled, ...rest
+  children, loadingText = 'Loading', loading = false, disabled = false, ...rest
 }, ref) => {
   const [loaderColour, setLoaderColour] = useState(null);
 
@@ -53,12 +53,6 @@ ButtonWithStates.propTypes = {
   loadingText: PropTypes.string,
   loading: PropTypes.bool,
   disabled: PropTypes.bool
-};
-
-ButtonWithStates.defaultProps = {
-  loading: false,
-  disabled: false,
-  loadingText: 'Loading'
 };
 
 export default ButtonWithStates;

--- a/src/components/Atoms/Checkbox/Checkbox.js
+++ b/src/components/Atoms/Checkbox/Checkbox.js
@@ -45,7 +45,7 @@ const Label = styled.label`
 `;
 
 const Checkbox = React.forwardRef(({
-  label, value, children, ...rest
+  label = undefined, value, children = undefined, ...rest
 }, ref) => (
   <Label hasLabelAsString={!!label}>
     <StyledCheckboxInput {...rest} value={value} ref={ref} />
@@ -59,11 +59,6 @@ Checkbox.propTypes = {
   value: PropTypes.string.isRequired,
   label: PropTypes.string,
   children: PropTypes.node
-};
-
-Checkbox.defaultProps = {
-  label: undefined,
-  children: undefined
 };
 
 export default Checkbox;

--- a/src/components/Atoms/Confetti/Confetti.js
+++ b/src/components/Atoms/Confetti/Confetti.js
@@ -31,7 +31,7 @@ function getAnimationSettings(originXA, originXB) {
   };
 }
 
-export default function Confetti({ trigger, duration }) {
+export default function Confetti({ trigger, duration = 3000 }) {
   const refAnimationInstance = useRef(null);
   const [intervalId, setIntervalId] = useState();
 
@@ -95,10 +95,6 @@ export default function Confetti({ trigger, duration }) {
     </>
   );
 }
-
-Confetti.defaultProps = {
-  duration: 3000
-};
 
 Confetti.propTypes = {
   trigger: PropTypes.bool.isRequired,

--- a/src/components/Atoms/Icons/Arrow.js
+++ b/src/components/Atoms/Icons/Arrow.js
@@ -22,7 +22,7 @@ const Icon = styled.svg`
 `;
 
 const Arrow = ({
-  colour, mobileColour, theme, size, direction, ...rest
+  colour = 'white', mobileColour = null, theme, size = 24, direction = 'up', ...rest
 }) => (
   <Icon
     direction={direction}
@@ -44,13 +44,6 @@ Arrow.propTypes = {
   size: PropTypes.number,
   direction: PropTypes.oneOf(['up', 'down', 'left', 'right']),
   theme: PropTypes.objectOf(PropTypes.shape).isRequired
-};
-
-Arrow.defaultProps = {
-  colour: 'white',
-  mobileColour: null,
-  size: 24,
-  direction: 'up'
 };
 
 export default withTheme(Arrow);

--- a/src/components/Atoms/Icons/AtSign.js
+++ b/src/components/Atoms/Icons/AtSign.js
@@ -15,7 +15,7 @@ const StyledSVG = styled.svg`
 `;
 
 const AtSign = ({
-  theme, size, colour, mobileColour, ...rest
+  theme, size = 24, colour = 'white', mobileColour = null, ...rest
 }) => (
   <StyledSVG
     width={size}
@@ -34,12 +34,6 @@ AtSign.propTypes = {
   size: PropTypes.number,
   colour: PropTypes.string,
   mobileColour: PropTypes.string
-};
-
-AtSign.defaultProps = {
-  size: 24,
-  colour: 'white',
-  mobileColour: null
 };
 
 export default withTheme(AtSign);

--- a/src/components/Atoms/Icons/Chevron.js
+++ b/src/components/Atoms/Icons/Chevron.js
@@ -22,7 +22,7 @@ const Icon = styled.svg`
 `;
 
 const Chevron = ({
-  colour, mobileColour, theme, size, direction, ...rest
+  colour = 'white', mobileColour = null, theme, size = 24, direction = 'up', ...rest
 }) => (
   <Icon
     direction={direction}
@@ -45,13 +45,6 @@ Chevron.propTypes = {
   size: PropTypes.number,
   direction: PropTypes.oneOf(['up', 'down', 'left', 'right']),
   theme: PropTypes.objectOf(PropTypes.shape).isRequired
-};
-
-Chevron.defaultProps = {
-  colour: 'white',
-  mobileColour: null,
-  size: 24,
-  direction: 'up'
 };
 
 export default withTheme(Chevron);

--- a/src/components/Atoms/Icons/Download.js
+++ b/src/components/Atoms/Icons/Download.js
@@ -13,7 +13,7 @@ const StyledSVG = styled.svg`
 `;
 
 const Download = ({
-  colour, mobileColour, theme, size, ...rest
+  colour = 'white', mobileColour = null, theme, size = 24, ...rest
 }) => (
   <StyledSVG
     {...rest}
@@ -34,12 +34,6 @@ Download.propTypes = {
   mobileColour: PropTypes.string,
   size: PropTypes.number,
   theme: PropTypes.objectOf(PropTypes.shape).isRequired
-};
-
-Download.defaultProps = {
-  colour: 'white',
-  mobileColour: null,
-  size: 24
 };
 
 export default withTheme(Download);

--- a/src/components/Atoms/Icons/External.js
+++ b/src/components/Atoms/Icons/External.js
@@ -13,7 +13,7 @@ const StyledSVG = styled.svg`
 `;
 
 const External = ({
-  colour, mobileColour, theme, size, ...rest
+  colour = 'white', mobileColour = null, theme, size = 24, ...rest
 }) => (
   <StyledSVG
     {...rest}
@@ -34,12 +34,6 @@ External.propTypes = {
   mobileColour: PropTypes.string,
   size: PropTypes.number,
   theme: PropTypes.objectOf(PropTypes.shape).isRequired
-};
-
-External.defaultProps = {
-  colour: 'white',
-  mobileColour: null,
-  size: 24
 };
 
 export default withTheme(External);

--- a/src/components/Atoms/Icons/Favourite.js
+++ b/src/components/Atoms/Icons/Favourite.js
@@ -13,7 +13,7 @@ const StyledSVG = styled.svg`
 `;
 
 const Favourite = ({
-  colour, mobileColour, theme, size, ...rest
+  colour = 'white', mobileColour = null, theme, size = 24, ...rest
 }) => (
   <StyledSVG
     {...rest}
@@ -34,12 +34,6 @@ Favourite.propTypes = {
   mobileColour: PropTypes.string,
   size: PropTypes.number,
   theme: PropTypes.objectOf(PropTypes.shape).isRequired
-};
-
-Favourite.defaultProps = {
-  colour: 'white',
-  mobileColour: null,
-  size: 24
 };
 
 export default withTheme(Favourite);

--- a/src/components/Atoms/Icons/Internal.js
+++ b/src/components/Atoms/Icons/Internal.js
@@ -13,7 +13,7 @@ const StyledSVG = styled.svg`
 `;
 
 const Internal = ({
-  colour, mobileColour, theme, size, ...rest
+  colour = 'white', mobileColour = null, theme, size = 24, ...rest
 }) => (
   <StyledSVG
     {...rest}
@@ -34,12 +34,6 @@ Internal.propTypes = {
   mobileColour: PropTypes.string,
   size: PropTypes.number,
   theme: PropTypes.objectOf(PropTypes.shape).isRequired
-};
-
-Internal.defaultProps = {
-  colour: 'white',
-  mobileColour: null,
-  size: 24
 };
 
 export default withTheme(Internal);

--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -59,14 +59,12 @@ const Prefix = styled.div`
   margin-left: 2px; // Just doesn't look quite right without this.
 `;
 
-
 const Input = React.forwardRef(
   (
     {
       errorMsg = '',
       id,
       label,
-      placeholder = '',
       showLabel = true,
       type,
       hasAria = true,

--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -59,19 +59,21 @@ const Prefix = styled.div`
   margin-left: 2px; // Just doesn't look quite right without this.
 `;
 
+
 const Input = React.forwardRef(
   (
     {
-      errorMsg,
+      errorMsg = '',
       id,
       label,
-      showLabel,
+      placeholder = '',
+      showLabel = true,
       type,
-      hasAria,
-      className,
-      labelProps,
-      prefix,
-      optional,
+      hasAria = true,
+      className = '',
+      labelProps = {},
+      prefix = '',
+      optional = null,
       ...rest
     },
     ref
@@ -125,17 +127,6 @@ Input.propTypes = {
   className: PropTypes.string,
   prefix: PropTypes.string,
   optional: PropTypes.bool
-};
-
-Input.defaultProps = {
-  showLabel: true,
-  hasAria: true,
-  placeholder: '',
-  errorMsg: '',
-  labelProps: {},
-  className: '',
-  prefix: '',
-  optional: null
 };
 
 export default Input;

--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -69,6 +69,7 @@ const Input = React.forwardRef(
       type,
       hasAria = true,
       className = '',
+      placeholder = '',
       labelProps = {},
       prefix = '',
       optional = null,
@@ -90,6 +91,7 @@ const Input = React.forwardRef(
         <InputField
           id={id}
           type={type}
+          placeholder={placeholder}
           error={!!errorMsg}
           aria-describedby={hasAria ? id : undefined}
           ref={ref}

--- a/src/components/Atoms/Label/Label.js
+++ b/src/components/Atoms/Label/Label.js
@@ -47,10 +47,10 @@ const LabelText = ({
  * @constructor
  */
 const Label = ({
-  children,
+  children = null,
   label,
-  hideLabel,
-  optional,
+  hideLabel = false,
+  optional = null,
   ...rest
 }) => (
   <LabelElement {...rest} optional={optional}>
@@ -70,12 +70,6 @@ Label.propTypes = {
   optional: PropTypes.bool
 };
 
-Label.defaultProps = {
-  hideLabel: false,
-  children: null,
-  optional: null
-};
-
 LabelText.propTypes = {
   label: PropTypes.oneOfType([
     PropTypes.string,
@@ -85,8 +79,4 @@ LabelText.propTypes = {
   children: PropTypes.node
 };
 
-LabelText.defaultProps = {
-  hideLabel: false,
-  children: null
-};
 export default Label;

--- a/src/components/Atoms/Link/Link.js
+++ b/src/components/Atoms/Link/Link.js
@@ -9,15 +9,15 @@ let window = '';
 
 const Link = ({
   children,
-  color,
-  mobileColour,
+  color = 'red',
+  mobileColour = null,
   href,
-  target,
-  type,
-  home,
-  underline,
-  icon,
-  iconFirst,
+  target = null,
+  type = 'standard',
+  home = false,
+  underline = true,
+  icon = null,
+  iconFirst = false,
   ...rest
 }) => {
   const [documentHost, setDocumentHost] = useState('');
@@ -59,6 +59,7 @@ const Link = ({
       href={href}
       target={window}
       type={type}
+      home={home}
       iconFirst={iconFirst}
       underline={underline}
     >
@@ -87,17 +88,6 @@ Link.propTypes = {
   iconFirst: PropTypes.bool,
   /** Embed icons */
   icon: PropTypes.node
-};
-
-Link.defaultProps = {
-  type: 'standard',
-  color: 'red',
-  mobileColour: null,
-  target: null,
-  home: false,
-  underline: true,
-  iconFirst: false,
-  icon: null
 };
 
 export default Link;

--- a/src/components/Atoms/Logo/Logo.js
+++ b/src/components/Atoms/Logo/Logo.js
@@ -46,7 +46,7 @@ const themeSwitcher = theme => {
 };
 
 const Logo = ({
-  rotate, sizeSm, sizeMd, campaign
+  rotate = false, sizeSm = '51px', sizeMd = '70px', campaign = 'Comic Relief'
 }) => (
   <LogoWrapper rotate={rotate ? 1 : 0} sizeSm={sizeSm} sizeMd={sizeMd}>
     <Image
@@ -66,13 +66,6 @@ Logo.propTypes = {
   sizeSm: PropTypes.string,
   sizeMd: PropTypes.string,
   campaign: PropTypes.string
-};
-
-Logo.defaultProps = {
-  rotate: false,
-  sizeSm: '51px', // - to work with the header 75px height and 12px padding
-  sizeMd: '70px',
-  campaign: 'Comic Relief'
 };
 
 export default Logo;

--- a/src/components/Atoms/Pagination/Pagination.js
+++ b/src/components/Atoms/Pagination/Pagination.js
@@ -6,30 +6,39 @@ import { getPages } from './Utils/PaginationCalculator';
 
 /** Customizable Pagination component */
 const Pagination = ({
-  PageComponent,
+  PageComponent = Item,
+  pageComponentProps = {},
+  showFirst = true,
+  showPrevious = true,
+  showNext = true,
+  showLast = true,
+  showMore = true,
+  maxPages = 5,
+  previousLabel = '‹',
+  nextLabel = '›',
+  firstLabel = '«',
+  lastLabel = '»',
+  moreLabel = '...',
+  getPageLabel = currentPage => currentPage.toString(),
+  previousAriaLabel = 'Previous page',
+  nextAriaLabel = 'Next page',
+  firstAriaLabel = 'First page',
+  lastAriaLabel = 'Last page',
+  moreAriaLabel = 'More pages',
+  getPageAriaLabel = currentPage => `Page ${currentPage}`,
+  target = 'self',
+  color = 'black',
+  backgroundColor = 'white',
+  selectedColor = 'white',
+  selectedBackgroundColor = 'red',
+  disabledColor = 'grey_medium',
+  disabledBackgroundColor = 'white',
+  colorOnHover = 'white',
+  backgroundColorOnHover = 'teal',
   totalPages,
-  maxPages,
   currentPage,
-  showFirst,
-  firstLabel,
-  firstAriaLabel,
-  showPrevious,
-  previousLabel,
-  previousAriaLabel,
-  showMore,
-  moreLabel,
-  moreAriaLabel,
-  showNext,
-  nextLabel,
-  nextAriaLabel,
-  showLast,
-  lastLabel,
-  lastAriaLabel,
-  getPageLabel,
-  getPageAriaLabel,
   onSelect,
   createURL,
-  pageComponentProps,
   ...restProps
 }) => {
   if (!totalPages) {
@@ -95,6 +104,15 @@ const Pagination = ({
       pageComponentProps={pageComponentProps}
       createURL={createURL}
       onSelect={onSelect}
+      target={target}
+      color={color}
+      backgroundColor={backgroundColor}
+      selectedColor={selectedColor}
+      selectedBackgroundColor={selectedBackgroundColor}
+      disabledColor={disabledColor}
+      disabledBackgroundColor={disabledBackgroundColor}
+      colorOnHover={colorOnHover}
+      backgroundColorOnHover={backgroundColorOnHover}
       {...restProps}
     />
   );
@@ -181,35 +199,4 @@ Pagination.propTypes = {
   backgroundColorOnHover: PropTypes.string
 };
 
-Pagination.defaultProps = {
-  PageComponent: Item,
-  pageComponentProps: {},
-  showFirst: true,
-  showPrevious: true,
-  showNext: true,
-  showLast: true,
-  showMore: true,
-  maxPages: 5,
-  previousLabel: '‹',
-  nextLabel: '›',
-  firstLabel: '«',
-  lastLabel: '»',
-  moreLabel: '...',
-  getPageLabel: currentPage => currentPage.toString(),
-  previousAriaLabel: 'Previous page',
-  nextAriaLabel: 'Next page',
-  firstAriaLabel: 'First page',
-  lastAriaLabel: 'Last page',
-  moreAriaLabel: 'More pages',
-  getPageAriaLabel: currentPage => `Page ${currentPage}`,
-  target: 'self',
-  color: 'black',
-  backgroundColor: 'white',
-  selectedColor: 'white',
-  selectedBackgroundColor: 'red',
-  disabledColor: 'grey_medium',
-  disabledBackgroundColor: 'white',
-  colorOnHover: 'white',
-  backgroundColorOnHover: 'teal'
-};
 export default Pagination;

--- a/src/components/Atoms/Picture/Picture.js
+++ b/src/components/Atoms/Picture/Picture.js
@@ -65,16 +65,16 @@ const Image = styled.img`
 
 /** Responsive Picture */
 const Picture = ({
-  images,
-  image,
-  alt,
-  width,
-  height,
-  objectFit,
-  imageLow,
-  isBackgroundImage,
-  smallBreakpointRowLayout,
-  mediumBreakpointRowLayout,
+  images = null,
+  image = null,
+  alt = '',
+  width = '100%',
+  height = 'auto',
+  objectFit = 'none',
+  imageLow = null,
+  isBackgroundImage = false,
+  smallBreakpointRowLayout = null,
+  mediumBreakpointRowLayout = null,
   ...rest
 }) => {
   const document = typeof window !== 'undefined' ? window.document : null;
@@ -170,19 +170,6 @@ Picture.propTypes = {
   isBackgroundImage: PropTypes.bool,
   smallBreakpointRowLayout: PropTypes.bool,
   mediumBreakpointRowLayout: PropTypes.bool
-};
-
-Picture.defaultProps = {
-  imageLow: null,
-  image: null,
-  images: null,
-  objectFit: 'none',
-  width: '100%',
-  height: 'auto',
-  alt: '',
-  isBackgroundImage: false,
-  smallBreakpointRowLayout: null,
-  mediumBreakpointRowLayout: null
 };
 
 export default withTheme(Picture);

--- a/src/components/Atoms/RichText/RichText.js
+++ b/src/components/Atoms/RichText/RichText.js
@@ -6,7 +6,7 @@ export const Inner = styled.div`
   text-align: ${props => props.align};
 `;
 
-const RichText = ({ align, markup, ...rest }) => (
+const RichText = ({ align = 'left', markup = '', ...rest }) => (
   <Inner
     align={align}
     dangerouslySetInnerHTML={{ __html: markup }}
@@ -17,11 +17,6 @@ const RichText = ({ align, markup, ...rest }) => (
 RichText.propTypes = {
   align: PropTypes.oneOf(['left', 'center', 'right']),
   markup: PropTypes.string
-};
-
-RichText.defaultProps = {
-  align: 'left',
-  markup: ''
 };
 
 export default RichText;

--- a/src/components/Atoms/Select/Select.js
+++ b/src/components/Atoms/Select/Select.js
@@ -44,12 +44,12 @@ const Select = React.forwardRef(
       description,
       label,
       options,
-      hideLabel,
-      defaultValue,
-      onChange,
-      greyDescription,
-      className,
-      optional,
+      hideLabel = false,
+      defaultValue = '',
+      onChange = null,
+      greyDescription = false,
+      className = '',
+      optional = false,
       ...rest
     },
     ref
@@ -112,17 +112,6 @@ Select.propTypes = {
   // (as `rest` is not spread on the outermost component)
   className: PropTypes.string,
   optional: PropTypes.bool
-};
-
-Select.defaultProps = {
-  hideLabel: false,
-  defaultValue: '',
-  onChange: null,
-  /** If true, the 'description' option, which is initially selected but disabled, will be grey
-   *   - like a text input's placeholder */
-  greyDescription: false,
-  className: '',
-  optional: false
 };
 
 export default Select;

--- a/src/components/Atoms/SocialIcons/SocialIcons.js
+++ b/src/components/Atoms/SocialIcons/SocialIcons.js
@@ -28,7 +28,7 @@ const StyledItem = styled.li`
 `;
 
 /** Social media icons with customizable style linked to campaign social media accounts */
-const SocialIcons = ({ campaign, ...restProps }) => {
+const SocialIcons = ({ target = 'blank', campaign, ...restProps }) => {
   const links = getLinks(campaign);
 
   return (
@@ -36,6 +36,7 @@ const SocialIcons = ({ campaign, ...restProps }) => {
       {Object.keys(icons).map(brand => (
         <StyledItem key={brand}>
           <Icon
+            target={target}
             icon={icons[brand]}
             href={links[brand].url}
             title={links[brand].title}
@@ -53,10 +54,6 @@ SocialIcons.propTypes = {
   campaign: PropTypes.string.isRequired,
   /** Social media account link target */
   target: PropTypes.string
-};
-
-SocialIcons.defaultProps = {
-  target: 'blank'
 };
 
 export default SocialIcons;

--- a/src/components/Atoms/Text/Text.js
+++ b/src/components/Atoms/Text/Text.js
@@ -51,11 +51,14 @@ export const BaseText = styled.span`
  *  Weight is checked for existence to prevent overriding the tag's css
  */
 const Text = ({
-  tag, children, height, weight, family, mobileColor, ...rest
+  tag = 'span', size = 's', color = 'inherit', children = undefined, uppercase = false, height = undefined, weight = undefined, family = null, mobileColor = null, ...rest
 }) => (
   <BaseText
     {...rest}
     as={tag}
+    color={color}
+    size={size}
+    uppercase={uppercase}
     height={height}
     weight={weight}
     family={family}
@@ -86,18 +89,6 @@ Text.propTypes = {
     PropTypes.string
   ]),
   mobileColor: PropTypes.string
-};
-
-Text.defaultProps = {
-  family: null,
-  tag: 'span',
-  weight: undefined,
-  height: undefined,
-  uppercase: false,
-  size: 's',
-  color: 'inherit',
-  children: undefined,
-  mobileColor: null
 };
 
 export default Text;

--- a/src/components/Atoms/TextArea/TextArea.js
+++ b/src/components/Atoms/TextArea/TextArea.js
@@ -32,7 +32,7 @@ const StyledTextArea = styled.textarea`${({ theme, error }) => css`
 `}`;
 
 const TextArea = React.forwardRef(({
-  id, label, hideLabel, errorMsg, rows, className, ...rest
+  id, label, placeholder = '', hideLabel = false, errorMsg = undefined, rows = 4, className = '', ...rest
 }, ref) => (
   <Label
     htmlFor={id}
@@ -43,6 +43,7 @@ const TextArea = React.forwardRef(({
   >
     <StyledTextArea
       {...rest}
+      placeholder={placeholder}
       rows={rows}
       error={!!errorMsg}
       aria-describedby={id}
@@ -66,14 +67,6 @@ TextArea.propTypes = {
   // className is needed so that styled(`TextArea`) will work
   // (as `rest` is not spread on the outermost component)
   className: PropTypes.string
-};
-
-TextArea.defaultProps = {
-  rows: 4,
-  placeholder: '',
-  errorMsg: undefined,
-  hideLabel: false,
-  className: ''
 };
 
 export default TextArea;

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -35,8 +35,8 @@ const TextInputWithDropdown = React.forwardRef(
       id,
       name,
       label,
-      dropdownInstruction,
-      className,
+      dropdownInstruction = null,
+      className = '',
       ...otherInputProps
     },
     ref
@@ -186,21 +186,12 @@ TextInputWithDropdown.propTypes = {
   dropdownInstruction: PropTypes.string
 };
 
-TextInputWithDropdown.defaultProps = {
-  dropdownInstruction: null,
-  className: ''
-};
-
 Options.propTypes = {
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
   onSelect: PropTypes.func.isRequired,
   dropdownInstruction: PropTypes.string,
   activeOption: PropTypes.number.isRequired,
   resetActiveOption: PropTypes.func.isRequired
-};
-
-Options.defaultProps = {
-  dropdownInstruction: null
 };
 
 export default TextInputWithDropdown;

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.js
@@ -135,14 +135,14 @@ const ArticleTeaser = ({
   href,
   date,
   title,
-  imageLow,
-  image,
-  images,
-  alt,
-  category,
-  logoSize,
-  family,
-  time
+  imageLow = null,
+  image = null,
+  images = null,
+  alt = '',
+  category = null,
+  logoSize = null,
+  family = 'Anton',
+  time = null
 }) => (
   <Wrapper>
     <Link href={href} type="standard" category={category} underline={false}>
@@ -207,17 +207,6 @@ ArticleTeaser.propTypes = {
   time: PropTypes.string,
   /** link url */
   href: PropTypes.string.isRequired
-};
-
-ArticleTeaser.defaultProps = {
-  imageLow: null,
-  image: null,
-  images: null,
-  category: null,
-  logoSize: null,
-  time: null,
-  alt: '',
-  family: 'Anton'
 };
 
 export default ArticleTeaser;

--- a/src/components/Molecules/Banner/Banner.js
+++ b/src/components/Molecules/Banner/Banner.js
@@ -24,7 +24,7 @@ const Container = styled.div`
   }
 `;
 
-const Banner = ({ children, backgroundColor }) => (
+const Banner = ({ children, backgroundColor = 'grey_dark' }) => (
   <Wrapper backgroundColor={backgroundColor}>
     <Container>
       { children }
@@ -35,10 +35,6 @@ const Banner = ({ children, backgroundColor }) => (
 Banner.propTypes = {
   children: PropTypes.node.isRequired,
   backgroundColor: PropTypes.string
-};
-
-Banner.defaultProps = {
-  backgroundColor: 'grey_dark'
 };
 
 export default Banner;

--- a/src/components/Molecules/Box/Box.js
+++ b/src/components/Molecules/Box/Box.js
@@ -44,14 +44,13 @@ const Copy = styled.div`
 `;
 
 const Box = ({
-  imageLow,
-  images,
-  image,
+  imageLow = null,
+  images = null,
+  image = null,
   imageAltText,
-  height,
-  width,
-  children,
-  squaredCorners,
+  width = '100%',
+  children = null,
+  squaredCorners = false,
   ...rest
 }) => (
   <Container {...rest}>
@@ -81,17 +80,6 @@ Box.propTypes = {
   imageAltText: PropTypes.string,
   children: PropTypes.node,
   squaredCorners: PropTypes.bool
-};
-
-Box.defaultProps = {
-  children: null,
-  imageLow: null,
-  images: null,
-  image: null,
-  imageAltText: '',
-  width: '100%',
-  height: '100%',
-  squaredCorners: false
 };
 
 export default Box;

--- a/src/components/Molecules/Card/Card.js
+++ b/src/components/Molecules/Card/Card.js
@@ -4,17 +4,17 @@ import Picture from '../../Atoms/Picture/Picture';
 import { Container, Wrapper, Copy } from './Card.style';
 
 const Card = ({
-  backgroundColor,
-  imageLow,
-  images,
-  image,
-  imageAltText,
-  height,
-  width,
-  children,
-  squaredCorners,
-  smallBreakpointRowLayout,
-  mediumBreakpointRowLayout,
+  backgroundColor = 'white',
+  children = null,
+  imageLow = null,
+  images = null,
+  image = null,
+  imageAltText = '',
+  width = '100%',
+  height = '100%',
+  squaredCorners = false,
+  smallBreakpointRowLayout = null,
+  mediumBreakpointRowLayout = null,
   ...rest
 }) => (
   <Container
@@ -63,20 +63,6 @@ Card.propTypes = {
   squaredCorners: PropTypes.bool,
   smallBreakpointRowLayout: PropTypes.bool,
   mediumBreakpointRowLayout: PropTypes.bool
-};
-
-Card.defaultProps = {
-  backgroundColor: 'white',
-  children: null,
-  imageLow: null,
-  images: null,
-  image: null,
-  imageAltText: '',
-  width: '100%',
-  height: '100%',
-  squaredCorners: false,
-  smallBreakpointRowLayout: null,
-  mediumBreakpointRowLayout: null
 };
 
 export default Card;

--- a/src/components/Molecules/CardDs/CardDs.js
+++ b/src/components/Molecules/CardDs/CardDs.js
@@ -7,18 +7,18 @@ import {
 } from './CardDs.style';
 
 const CardDs = ({
-  icon,
-  backgroundColor,
-  imageLow,
-  images,
-  image,
-  imageAltText,
-  height,
-  width,
+  backgroundColor = 'white',
+  imageLow = null,
+  images = null,
+  image = null,
+  link = null,
+  linkLabel = null,
+  target = null,
+  imageAltText = '',
+  width = '100%',
+  height = '100%',
+  icon = null,
   children,
-  link,
-  linkLabel,
-  target,
   ...rest
 }) => {
   const Media = (
@@ -100,20 +100,6 @@ CardDs.propTypes = {
   target: PropTypes.string,
   children: PropTypes.node.isRequired,
   icon: PropTypes.node
-};
-
-CardDs.defaultProps = {
-  backgroundColor: 'white',
-  imageLow: null,
-  images: null,
-  image: null,
-  link: null,
-  linkLabel: null,
-  target: null,
-  imageAltText: '',
-  width: '100%',
-  height: '100%',
-  icon: null
 };
 
 export default CardDs;

--- a/src/components/Molecules/Chip/Chip.js
+++ b/src/components/Molecules/Chip/Chip.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { CheckLabel, Overlay, CheckInput } from './Chip.style';
 
 const Chip = ({
-  category, handleToggle, color, checked
+  category, handleToggle, color = 'purple', checked = false
 }) => (
   <CheckLabel>
     <CheckInput
@@ -25,11 +25,6 @@ Chip.propTypes = {
   color: PropTypes.string,
   checked: PropTypes.bool,
   handleToggle: PropTypes.func.isRequired
-};
-
-Chip.defaultProps = {
-  color: 'purple',
-  checked: false
 };
 
 export default Chip;

--- a/src/components/Molecules/Countdown/Countdown.js
+++ b/src/components/Molecules/Countdown/Countdown.js
@@ -5,7 +5,7 @@ import Text from '../../Atoms/Text/Text';
 import { Wrapper, Digits } from './Countdown.style';
 
 const Countdown = ({
-  endDate, color, endMessage, introMessage
+  endDate, color = 'black', endMessage = null, introMessage = null
 }) => {
   const [countdownHasEnded, setCountdownHasEnded] = useState(false);
   const [countdownTime, setCountdownTime] = useState({
@@ -95,12 +95,6 @@ Countdown.propTypes = {
   color: PropTypes.string,
   endMessage: PropTypes.node,
   introMessage: PropTypes.node
-};
-
-Countdown.defaultProps = {
-  color: 'black',
-  endMessage: null,
-  introMessage: null
 };
 
 export default Countdown;

--- a/src/components/Molecules/Logos/Logos.js
+++ b/src/components/Molecules/Logos/Logos.js
@@ -10,7 +10,7 @@ const TitleLabel = styled.span`
   color: transparent; 
 `;
 
-const Logos = ({ campaign }) => {
+const Logos = ({ campaign = 'Comic Relief' }) => {
   if (campaign === 'Sport Relief Gameon') {
     return (
       <>
@@ -54,10 +54,6 @@ const Logos = ({ campaign }) => {
 
 Logos.propTypes = {
   campaign: PropTypes.string
-};
-
-Logos.defaultProps = {
-  campaign: 'Comic Relief'
 };
 
 export default Logos;

--- a/src/components/Molecules/Lookup/Lookup.js
+++ b/src/components/Molecules/Lookup/Lookup.js
@@ -57,8 +57,8 @@ const Lookup = ({
   lookupHandler,
   mapOptionToString,
   onSelect,
-  noResultsMessage,
-  dropdownInstruction,
+  noResultsMessage = 'Sorry, could not find any results for your search',
+  dropdownInstruction = '',
   ...rest
 }) => {
   const [query, setQuery] = useState('');
@@ -138,11 +138,6 @@ Lookup.propTypes = {
   onSelect: PropTypes.func.isRequired,
   noResultsMessage: PropTypes.string,
   dropdownInstruction: PropTypes.string
-};
-
-Lookup.defaultProps = {
-  noResultsMessage: 'Sorry, could not find any results for your search',
-  dropdownInstruction: ''
 };
 
 export default Lookup;

--- a/src/components/Molecules/Promo/Promo.js
+++ b/src/components/Molecules/Promo/Promo.js
@@ -10,23 +10,23 @@ import {
 } from './Promo.style';
 
 const Promo = ({
-  copyLeft,
-  backgroundColor,
-  imageLow,
-  imageSet,
-  image,
-  imageAltText,
-  children,
-  position,
-  autoPlay,
-  loop,
-  poster,
-  mobilePoster,
-  showPosterAfterPlaying,
-  videoSrc,
-  mobileVideoSrc,
-  behindTextGradient,
-  blackPlayButton
+  backgroundColor = 'white',
+  copyLeft = false,
+  imageSet = null,
+  imageLow = null,
+  image = null,
+  imageAltText = '',
+  children = null,
+  position = 'none',
+  autoPlay = true,
+  loop = true,
+  poster = null,
+  mobilePoster = null,
+  videoSrc = null,
+  mobileVideoSrc = null,
+  showPosterAfterPlaying = true,
+  behindTextGradient = 'none',
+  blackPlayButton = false
 }) => {
   // Store the appropriate prop in state, dependent on the breakpoint
   const [thisVideoSrc, setThisVideoSrc] = useState(null);
@@ -122,26 +122,6 @@ Promo.propTypes = {
   showPosterAfterPlaying: PropTypes.bool,
   behindTextGradient: PropTypes.oneOf(['black', 'white', 'none']),
   blackPlayButton: PropTypes.bool
-};
-
-Promo.defaultProps = {
-  backgroundColor: 'white',
-  copyLeft: false,
-  imageSet: null,
-  imageLow: null,
-  image: null,
-  imageAltText: '',
-  children: null,
-  position: 'none',
-  autoPlay: true,
-  loop: true,
-  poster: null,
-  mobilePoster: null,
-  videoSrc: null,
-  mobileVideoSrc: null,
-  showPosterAfterPlaying: true,
-  behindTextGradient: 'none',
-  blackPlayButton: false
 };
 
 export default Promo;

--- a/src/components/Molecules/SchoolLookup/SchoolLookup.js
+++ b/src/components/Molecules/SchoolLookup/SchoolLookup.js
@@ -20,10 +20,10 @@ const optionParser = school => `${school.name}, ${school.post_code}`;
 const SchoolLookup = React.forwardRef(
   (
     {
-      label,
-      placeholder,
-      notFoundMessage,
-      dropdownInstruction,
+      label = 'Enter the name or postcode of your school or nursery',
+      placeholder = 'Type to start search',
+      dropdownInstruction = 'Please select a school from the list below',
+      notFoundMessage = "Sorry, we can't find this school",
       onSelect,
       ...rest
     },
@@ -53,13 +53,6 @@ SchoolLookup.propTypes = {
   placeholder: PropTypes.string,
   dropdownInstruction: PropTypes.string,
   notFoundMessage: PropTypes.string
-};
-
-SchoolLookup.defaultProps = {
-  label: 'Enter the name or postcode of your school or nursery',
-  placeholder: 'Type to start search',
-  dropdownInstruction: 'Please select a school from the list below',
-  notFoundMessage: "Sorry, we can't find this school"
 };
 
 export default SchoolLookup;

--- a/src/components/Molecules/SearchInput/SearchInput.js
+++ b/src/components/Molecules/SearchInput/SearchInput.js
@@ -10,7 +10,7 @@ import {
 } from './SearchInput.style';
 
 const SearchInput = ({
-  onChange, placeholder, value, ...rest
+  onChange, placeholder = '', value, ...rest
 }) => (
   <Wrapper>
     <InnerWrapper>
@@ -39,10 +39,6 @@ SearchInput.propTypes = {
   onChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
   value: PropTypes.string.isRequired
-};
-
-SearchInput.defaultProps = {
-  placeholder: ''
 };
 
 export default SearchInput;

--- a/src/components/Molecules/SearchResult/SearchResult.js
+++ b/src/components/Molecules/SearchResult/SearchResult.js
@@ -59,16 +59,16 @@ const Title = styled(Text)`
  * Search Result component
  */
 const SearchResult = ({
+  imageLow = null,
+  images = null,
+  type = '',
+  date = '',
+  copy = '',
+  smallImageWidth = '45%',
+  largeImageWidth = '100%',
   href,
-  date,
   title,
-  copy,
-  type,
-  imageLow,
-  images,
-  alt,
-  smallImageWidth,
-  largeImageWidth
+  alt
 }) => (
   <Wrapper>
     <Item href={href} type="standard">
@@ -120,16 +120,6 @@ SearchResult.propTypes = {
   /** image url */
   images: PropTypes.string,
   imageLow: PropTypes.string
-};
-
-SearchResult.defaultProps = {
-  imageLow: null,
-  images: null,
-  type: '',
-  date: '',
-  copy: '',
-  smallImageWidth: '45%',
-  largeImageWidth: '100%'
 };
 
 export default SearchResult;

--- a/src/components/Molecules/ShareButton/ShareButton.js
+++ b/src/components/Molecules/ShareButton/ShareButton.js
@@ -27,7 +27,7 @@ const handleShare = (e, typeOfShare, urlToShare) => {
 
 /* Share Button component to handle FB and Twitter sharing */
 const ShareButton = ({
-  campaign, copy, urlToShare, ...restProps
+  campaign = 'comicrelief', copy = 'Share with:', urlToShare = null, ...restProps
 }) => {
   let checkedUrl = '';
 
@@ -68,12 +68,6 @@ ShareButton.propTypes = {
   campaign: PropTypes.string,
   copy: PropTypes.string,
   urlToShare: PropTypes.string
-};
-
-ShareButton.defaultProps = {
-  campaign: 'comicrelief',
-  copy: 'Share with:',
-  urlToShare: null
 };
 
 export default ShareButton;

--- a/src/components/Molecules/SimpleSchoolLookup/SimpleSchoolLookup.js
+++ b/src/components/Molecules/SimpleSchoolLookup/SimpleSchoolLookup.js
@@ -41,7 +41,10 @@ const schoolToString = school => `${school.name}, ${school.post_code}`;
  * @returns {JSX.Element}
  * @constructor
  */
-const SimpleSchoolLookup = ({ onSelect, noResultsMessage, ...rest }) => (
+const SimpleSchoolLookup = ({
+  onSelect, noResultsMessage = 'Sorry, we could not find anything matching your search; please use the manual entry option.',
+  ...rest
+}) => (
   <Lookup
     name="school_lookup"
     label="Enter the name or postcode of your organisation"
@@ -55,10 +58,6 @@ const SimpleSchoolLookup = ({ onSelect, noResultsMessage, ...rest }) => (
     {...rest}
   />
 );
-
-SimpleSchoolLookup.defaultProps = {
-  noResultsMessage: 'Sorry, we could not find anything matching your search; please use the manual entry option.'
-};
 
 SimpleSchoolLookup.propTypes = {
   onSelect: PropTypes.func.isRequired,

--- a/src/components/Molecules/SingleMessage/SingleMessage.js
+++ b/src/components/Molecules/SingleMessage/SingleMessage.js
@@ -17,21 +17,21 @@ const allPlayers = {};
 
 /* Single Message is our main component usually to build landing pages */
 const SingleMessage = ({
-  backgroundColor,
-  copyFirst,
-  imageLow,
-  imageSet,
-  image,
-  imageSet2,
-  image2,
-  imageAltText,
-  imageAltText2,
-  children,
-  fullImage,
-  vhFull,
-  videoID,
-  landscapeVideo,
-  paddingOption
+  backgroundColor = 'white',
+  copyFirst = false,
+  fullImage = false,
+  imageSet = null,
+  imageLow = null,
+  image = null,
+  imageSet2 = null,
+  image2 = null,
+  imageAltText = '',
+  imageAltText2 = '',
+  children = null,
+  vhFull = false,
+  videoID = null,
+  landscapeVideo = false,
+  paddingOption = null
 }) => {
   const hasImage = imageSet || false;
   const doubleImage = (imageSet || image) && (imageSet2 || image2);
@@ -238,24 +238,6 @@ SingleMessage.propTypes = {
   videoID: PropTypes.string,
   landscapeVideo: PropTypes.bool,
   paddingOption: PropTypes.string
-};
-
-SingleMessage.defaultProps = {
-  backgroundColor: 'white',
-  copyFirst: false,
-  fullImage: false,
-  imageSet: null,
-  imageLow: null,
-  image: null,
-  imageSet2: null,
-  image2: null,
-  imageAltText: '',
-  imageAltText2: '',
-  children: null,
-  vhFull: false,
-  videoID: null,
-  landscapeVideo: false,
-  paddingOption: null
 };
 
 export default SingleMessage;

--- a/src/components/Molecules/SingleMessageDS/SingleMessageDs.js
+++ b/src/components/Molecules/SingleMessageDS/SingleMessageDs.js
@@ -11,22 +11,22 @@ import {
 import playImage from './assets/play.png';
 
 const SingleMessageDs = ({
-  backgroundColor,
+  backgroundColor = 'white',
+  imageLow = null,
+  images = null,
+  image = null,
+  link = null,
+  ctaBgColor = 'red',
+  linkLabel = null,
+  target = null,
+  imageAltText = '',
+  width = '100%',
+  height = '100%',
+  linkIcon = null,
+  youTubeId = null,
   imageLeft,
-  imageLow,
-  images,
-  image,
-  imageAltText,
-  height,
-  width,
   subtitle,
   children,
-  link,
-  linkLabel,
-  ctaBgColor,
-  target,
-  linkIcon,
-  youTubeId,
   ...rest
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -190,22 +190,6 @@ SingleMessageDs.propTypes = {
   children: PropTypes.node.isRequired,
   linkIcon: PropTypes.node,
   youTubeId: PropTypes.string
-};
-
-SingleMessageDs.defaultProps = {
-  backgroundColor: 'white',
-  imageLow: null,
-  images: null,
-  image: null,
-  link: null,
-  ctaBgColor: 'red',
-  linkLabel: null,
-  target: null,
-  imageAltText: '',
-  width: '100%',
-  height: '100%',
-  linkIcon: null,
-  youTubeId: null
 };
 
 export default SingleMessageDs;

--- a/src/components/Molecules/Typeahead/Typeahead.js
+++ b/src/components/Molecules/Typeahead/Typeahead.js
@@ -12,14 +12,14 @@ const Typeahead = React.forwardRef(
   (
     {
       optionFetcher,
-      optionParser,
+      optionParser = null,
       onSelect,
       id,
       label,
       name,
-      dropdownInstruction,
+      dropdownInstruction = null,
       notFoundMessage,
-      fetchErrorHandler,
+      fetchErrorHandler = () => 'Sorry, there was an unexpected error. Please try again',
       ...rest
     },
     ref
@@ -111,12 +111,6 @@ Typeahead.propTypes = {
    */
   fetchErrorHandler: PropTypes.func,
   dropdownInstruction: PropTypes.string
-};
-
-Typeahead.defaultProps = {
-  dropdownInstruction: null,
-  optionParser: null,
-  fetchErrorHandler: () => 'Sorry, there was an unexpected error. Please try again'
 };
 
 export default Typeahead;

--- a/src/components/Molecules/VideoBanner/VideoBanner.js
+++ b/src/components/Molecules/VideoBanner/VideoBanner.js
@@ -10,7 +10,13 @@ const Video = styled.video.attrs(() => ({
 `;
 
 const VideoBanner = ({
-  video, poster, controls, autoPlay, loop, muted, showPosterAfterPlaying
+  video,
+  poster,
+  controls = false,
+  autoPlay = true,
+  loop = false,
+  muted = true,
+  showPosterAfterPlaying = true
 }) => {
   // Use the prop as our default
   const [isMuted, setIsMuted] = useState(muted);
@@ -51,14 +57,6 @@ const VideoBanner = ({
       Your browser does not support video.
     </Video>
   );
-};
-
-VideoBanner.defaultProps = {
-  showPosterAfterPlaying: true,
-  controls: false,
-  autoPlay: true,
-  loop: false,
-  muted: true
 };
 
 VideoBanner.propTypes = {

--- a/src/components/Organisms/Donate/Donate.js
+++ b/src/components/Organisms/Donate/Donate.js
@@ -49,7 +49,9 @@ const Donate = ({
   cartID,
   clientID,
   paddingOption = null,
-  donateLink
+  donateLink,
+  monthlyChooseAmountText: monthlyChoose = '',
+  monthlyOtherAmountText: monthlyOther = ''
 }) => {
   let isDesktop = useMediaQuery({ query: `(min-width: ${breakpointValues.L}px)` });
 
@@ -76,7 +78,7 @@ const Donate = ({
   const {
     thisOtherAmountText,
     thisChooseAmountText
-  } = handleCopy(givingType, otherAmountText, chooseAmountText);
+  } = handleCopy(givingType, otherAmountText, chooseAmountText, monthlyOther, monthlyChoose);
 
   return (
     <Container
@@ -195,6 +197,8 @@ Donate.propTypes = {
   defaultGivingType: PropTypes.string,
   monthlyTitle: PropTypes.string,
   monthlySubtitle: PropTypes.string,
+  monthlyChooseAmountText: PropTypes.string,
+  monthlyOtherAmountText: PropTypes.string,
   paddingOption: PropTypes.string
 };
 

--- a/src/components/Organisms/Donate/Donate.js
+++ b/src/components/Organisms/Donate/Donate.js
@@ -17,41 +17,43 @@ import {
 } from './Donate.style';
 
 const Donate = ({
-  alt,
+  alt = '',
+  data = {},
+  formAlignRight = true,
+  imageLow = null,
+  image = null,
+  images = null,
+  mobileImageLow = null,
+  mobileImage = null,
+  mobileImages = null,
+  mobileAlt = '',
+  desktopOverlayColor = 'transparent',
+  mobileBackgroundColor = 'blue_dark',
+  submitButtonColor = 'red',
+  textColor = 'white',
+  mbshipID = null,
+  otherAmountText =
+    'will help us fund amazing projects in the UK and around the world.',
+  subtitle = '',
+  noMoneyBuys = false,
+  PopUpText = 'Help us deliver long-term impact by converting your single donation into a monthly gift.',
+  chooseAmountText = '',
+  isDesktopOverride = null,
+  otherAmountValue = null,
+  title = null,
+  additionalSingleCopy = null,
+  additionalMonthlyCopy = null,
+  defaultGivingType = null,
+  monthlyTitle = '',
+  monthlySubtitle = '',
   cartID,
   clientID,
-  desktopOverlayColor,
-  mobileBackgroundColor,
-  submitButtonColor,
-  textColor,
+  paddingOption = null,
   donateLink,
-  data,
-  title,
-  subtitle,
-  otherAmountText,
-  formAlignRight,
-  images,
-  image,
-  imageLow,
-  mobileImages,
-  mobileImage,
-  mobileImageLow,
-  mobileAlt,
-  mbshipID,
-  noMoneyBuys,
-  PopUpText,
-  chooseAmountText,
-  isDesktopOverride,
-  otherAmountValue,
-  additionalSingleCopy,
-  additionalMonthlyCopy,
-  defaultGivingType,
-  monthlyTitle,
-  monthlySubtitle,
-  paddingOption,
-  // Just to keep the function call character length under control
-  monthlyChooseAmountText: monthlyChoose,
-  monthlyOtherAmountText: monthlyOther
+  monthlyChooseAmountText = '', //
+  monthlyOtherAmountText = '', //
+  monthlyChooseAmountText =monthlyChoose, //
+  monthlyOtherAmountText =monthlyOther //
 }) => {
   let isDesktop = useMediaQuery({ query: `(min-width: ${breakpointValues.L}px)` });
 
@@ -200,41 +202,6 @@ Donate.propTypes = {
   monthlyChooseAmountText: PropTypes.string,
   monthlyOtherAmountText: PropTypes.string,
   paddingOption: PropTypes.string
-};
-
-Donate.defaultProps = {
-  alt: '',
-  data: {},
-  formAlignRight: true,
-  imageLow: null,
-  image: null,
-  images: null,
-  mobileImageLow: null,
-  mobileImage: null,
-  mobileImages: null,
-  mobileAlt: '',
-  desktopOverlayColor: 'transparent',
-  mobileBackgroundColor: 'blue_dark',
-  submitButtonColor: 'red',
-  textColor: 'white',
-  mbshipID: null,
-  otherAmountText:
-    'will help us fund amazing projects in the UK and around the world.',
-  subtitle: '',
-  noMoneyBuys: false,
-  PopUpText: 'Help us deliver long-term impact by converting your single donation into a monthly gift.',
-  chooseAmountText: '',
-  isDesktopOverride: null,
-  otherAmountValue: null,
-  title: null,
-  additionalSingleCopy: null,
-  additionalMonthlyCopy: null,
-  defaultGivingType: null,
-  monthlyTitle: '',
-  monthlySubtitle: '',
-  monthlyChooseAmountText: '',
-  monthlyOtherAmountText: '',
-  paddingOption: null
 };
 
 export default Donate;

--- a/src/components/Organisms/Donate/Donate.js
+++ b/src/components/Organisms/Donate/Donate.js
@@ -33,7 +33,7 @@ const Donate = ({
   textColor = 'white',
   mbshipID = null,
   otherAmountText =
-    'will help us fund amazing projects in the UK and around the world.',
+  'will help us fund amazing projects in the UK and around the world.',
   subtitle = '',
   noMoneyBuys = false,
   PopUpText = 'Help us deliver long-term impact by converting your single donation into a monthly gift.',
@@ -49,11 +49,7 @@ const Donate = ({
   cartID,
   clientID,
   paddingOption = null,
-  donateLink,
-  monthlyChooseAmountText = '', //
-  monthlyOtherAmountText = '', //
-  monthlyChooseAmountText =monthlyChoose, //
-  monthlyOtherAmountText =monthlyOther //
+  donateLink
 }) => {
   let isDesktop = useMediaQuery({ query: `(min-width: ${breakpointValues.L}px)` });
 
@@ -80,7 +76,7 @@ const Donate = ({
   const {
     thisOtherAmountText,
     thisChooseAmountText
-  } = handleCopy(givingType, otherAmountText, chooseAmountText, monthlyOther, monthlyChoose);
+  } = handleCopy(givingType, otherAmountText, chooseAmountText);
 
   return (
     <Container
@@ -199,8 +195,6 @@ Donate.propTypes = {
   defaultGivingType: PropTypes.string,
   monthlyTitle: PropTypes.string,
   monthlySubtitle: PropTypes.string,
-  monthlyChooseAmountText: PropTypes.string,
-  monthlyOtherAmountText: PropTypes.string,
   paddingOption: PropTypes.string
 };
 

--- a/src/components/Organisms/Donate/Form/Form.js
+++ b/src/components/Organisms/Donate/Form/Form.js
@@ -33,18 +33,18 @@ const Signup = ({
   clientID,
   cartID,
   mbshipID,
-  noMoneyBuys,
+  noMoneyBuys = false,
   PopUpText,
   chooseAmountText,
   submitButtonColor,
-  otherAmountValue,
-  additionalSingleCopy,
-  additionalMonthlyCopy,
-  defaultGivingType,
-  monthlyChooseAmountCopy,
-  monthlyOtherAmountCopy,
+  otherAmountValue = null,
+  additionalSingleCopy = null,
+  additionalMonthlyCopy = null,
+  defaultGivingType = null,
+  monthlyChooseAmountCopy = null,
+  monthlyOtherAmountCopy = null,
   changeGivingType,
-  givingType,
+  givingType = null,
   ...rest
 }) => {
   // const [givingType, setGivingType] = useState();
@@ -349,18 +349,6 @@ Signup.propTypes = {
   monthlyOtherAmountCopy: PropTypes.string,
   changeGivingType: PropTypes.func.isRequired,
   givingType: PropTypes.string
-};
-
-Signup.defaultProps = {
-  noMoneyBuys: false,
-  otherAmountValue: null,
-  data: {},
-  additionalSingleCopy: null,
-  additionalMonthlyCopy: null,
-  defaultGivingType: null,
-  monthlyChooseAmountCopy: null,
-  monthlyOtherAmountCopy: null,
-  givingType: null
 };
 
 export default Signup;

--- a/src/components/Organisms/Donate/Form/Form.js
+++ b/src/components/Organisms/Donate/Form/Form.js
@@ -41,8 +41,6 @@ const Signup = ({
   additionalSingleCopy = null,
   additionalMonthlyCopy = null,
   defaultGivingType = null,
-  monthlyChooseAmountCopy = null,
-  monthlyOtherAmountCopy = null,
   changeGivingType,
   givingType = null,
   ...rest
@@ -345,8 +343,6 @@ Signup.propTypes = {
   additionalSingleCopy: PropTypes.string,
   additionalMonthlyCopy: PropTypes.string,
   defaultGivingType: PropTypes.string,
-  monthlyChooseAmountCopy: PropTypes.string,
-  monthlyOtherAmountCopy: PropTypes.string,
   changeGivingType: PropTypes.func.isRequired,
   givingType: PropTypes.string
 };

--- a/src/components/Organisms/Donate/GivingSelector/GivingSelector.js
+++ b/src/components/Organisms/Donate/GivingSelector/GivingSelector.js
@@ -6,7 +6,7 @@ import {
 } from './GivingSelector.style';
 
 const GivingSelector = ({
-  givingType, changeGivingType, setPopOpen, mbshipID
+  givingType = null, changeGivingType, setPopOpen, mbshipID
 }) => {
   // Only updates giving type and popup status when appropriate
   const handleGivingTypeChange = (thisButtonType, currentGivingType) => {
@@ -49,10 +49,6 @@ const GivingSelector = ({
       </MoneyBox>
     </Wrapper>
   );
-};
-
-GivingSelector.defaultProps = {
-  givingType: null
 };
 
 GivingSelector.propTypes = {

--- a/src/components/Organisms/Donate/MoneyBuy/MoneyBuy.js
+++ b/src/components/Organisms/Donate/MoneyBuy/MoneyBuy.js
@@ -45,9 +45,9 @@ const MoneyBuyButton = styled(Input)`
 
 const MoneyBuy = ({
   setOtherAmount,
-  amount,
-  currency,
-  description,
+  amount = '10',
+  currency = '£',
+  description = 'description',
   ...rest
 }) => (
   <MoneyBuyButton
@@ -67,12 +67,6 @@ MoneyBuy.propTypes = {
   description: PropTypes.string,
   // Function already set doesn't need to be passed as props
   setOtherAmount: PropTypes.func.isRequired
-};
-
-MoneyBuy.defaultProps = {
-  amount: '10',
-  currency: '£',
-  description: 'description'
 };
 
 export default MoneyBuy;

--- a/src/components/Organisms/EmailSignUp/_EmailSignUp.js
+++ b/src/components/Organisms/EmailSignUp/_EmailSignUp.js
@@ -22,10 +22,10 @@ const EmailSignUp = ({
   topCopy,
   successCopy,
   privacyCopy,
-  backgroundColour,
-  buttonColour,
+  backgroundColour = 'deep_violet_dark',
+  buttonColour = 'red',
   formContext,
-  columnLayout,
+  columnLayout = false,
   ...rest
 }) => {
   const {
@@ -124,12 +124,6 @@ EmailSignUp.propTypes = {
   buttonColour: PropTypes.string,
   formContext: PropTypes.shape().isRequired,
   columnLayout: PropTypes.bool
-};
-
-EmailSignUp.defaultProps = {
-  backgroundColour: 'deep_violet_dark',
-  buttonColour: 'red',
-  columnLayout: false
 };
 
 export { EmailSignUp, buildEsuValidationSchema, ESU_FIELDS };

--- a/src/components/Organisms/EmailSignUp/_TextInput.js
+++ b/src/components/Organisms/EmailSignUp/_TextInput.js
@@ -7,9 +7,9 @@ import Input from '../../Atoms/Input/Input';
 const TextInput = ({
   fieldName,
   label,
-  optional,
-  fieldType,
-  formContext,
+  optional = null,
+  fieldType = 'text',
+  formContext = null,
   ...rest
 }) => {
   const { formState: { errors }, register } = formContext;
@@ -26,12 +26,6 @@ const TextInput = ({
   };
 
   return <Input {...props} {...register(fieldName)} />;
-};
-
-TextInput.defaultProps = {
-  optional: null,
-  fieldType: 'text',
-  formContext: null
 };
 
 TextInput.propTypes = {

--- a/src/components/Organisms/Footer/Footer.js
+++ b/src/components/Organisms/Footer/Footer.js
@@ -16,14 +16,14 @@ import {
 } from './Footer.style';
 
 const Footer = ({
-  navItems, footerCopy, campaign, additionalLegalLine, ...rest
+  navItems = {}, footerCopy = '', campaign = 'Comic Relief', additionalLegalLine = '', overrideallowList = false, ...rest
 }) => {
   // Remove white space between words
   const campaignName = campaign.replace(/\s/g, '').toLowerCase();
 
   return (
     <div>
-      <FooterWrapper navItems {...rest}>
+      <FooterWrapper overrideallowList={overrideallowList} navItems {...rest}>
         <InnerWrapper>
           {additionalLegalLine
             && <FooterLegalLine tag="p" color="grey">{additionalLegalLine}</FooterLegalLine>
@@ -54,14 +54,6 @@ Footer.propTypes = {
   campaign: PropTypes.string,
   overrideallowList: PropTypes.bool,
   additionalLegalLine: PropTypes.string
-};
-
-Footer.defaultProps = {
-  navItems: {},
-  footerCopy: '',
-  campaign: 'Comic Relief',
-  overrideallowList: false,
-  additionalLegalLine: ''
 };
 
 export default Footer;

--- a/src/components/Organisms/Footer/Nav/Nav.js
+++ b/src/components/Organisms/Footer/Nav/Nav.js
@@ -16,7 +16,7 @@ import {
   SubNavLink
 } from './Nav.style';
 
-const FooterNav = ({ navItems, ...rest }) => {
+const FooterNav = ({ navItems = {}, ...rest }) => {
   const { menuGroups } = navItems;
   const [isExpandable] = useState(false);
   const [isSubMenuOpen, setIsSubMenuOpen] = useState({});
@@ -121,10 +121,6 @@ const FooterNav = ({ navItems, ...rest }) => {
 
 FooterNav.propTypes = {
   navItems: PropTypes.objectOf(PropTypes.shape)
-};
-
-FooterNav.defaultProps = {
-  navItems: {}
 };
 
 export default FooterNav;

--- a/src/components/Organisms/Header/Header.js
+++ b/src/components/Organisms/Header/Header.js
@@ -8,7 +8,7 @@ import {
 } from './Header.style';
 
 const Header = ({
-  navItems, metaIcons, campaign, ...rest
+  navItems = {}, metaIcons, campaign = 'Comic Relief', ...rest
 }) => (
   <HeaderWrapper navItems {...rest}>
     <InnerWrapper>
@@ -27,11 +27,6 @@ Header.propTypes = {
   /** it can be icons, buttons  */
   metaIcons: PropTypes.node.isRequired,
   campaign: PropTypes.string
-};
-
-Header.defaultProps = {
-  navItems: {},
-  campaign: 'Comic Relief'
 };
 
 export default Header;

--- a/src/components/Organisms/Header/Nav/Nav.js
+++ b/src/components/Organisms/Header/Nav/Nav.js
@@ -21,7 +21,7 @@ import {
   ChevronWrapper
 } from './Nav.style';
 
-const MainNav = ({ navItems }) => {
+const MainNav = ({ navItems = {} }) => {
   const { menuGroups } = navItems;
   const [isExpandable, setIsExpandable] = useState(false);
   const [isSubMenuOpen, setIsSubMenuOpen] = useState({});
@@ -178,10 +178,6 @@ const MainNav = ({ navItems }) => {
 
 MainNav.propTypes = {
   navItems: PropTypes.objectOf(PropTypes.shape)
-};
-
-MainNav.defaultProps = {
-  navItems: {}
 };
 
 export default MainNav;

--- a/src/components/Organisms/ImpactSlider/ImpactSlider.js
+++ b/src/components/Organisms/ImpactSlider/ImpactSlider.js
@@ -11,7 +11,7 @@ import {
 
 const ImpactSlider = ({
   heading, cartID, donateLink, rowID, items, step, max,
-  backgroundColour, opacityAnimation, children, defaultSliderValue
+  backgroundColour = 'grey_extra_light', opacityAnimation = false, children, defaultSliderValue = null
 }) => {
   // Use the lowest possible amount as our default:
   const [currentAmount, setCurrentAmount] = useState(defaultSliderValue || step);
@@ -63,12 +63,6 @@ const ImpactSlider = ({
       </InnerWrapper>
     </OuterWrapper>
   );
-};
-
-ImpactSlider.defaultProps = {
-  opacityAnimation: false,
-  defaultSliderValue: null,
-  backgroundColour: 'grey_extra_light'
 };
 
 ImpactSlider.propTypes = {

--- a/src/components/Organisms/MarketingPreferencesDS/_CheckAnswer.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_CheckAnswer.js
@@ -9,7 +9,7 @@ import {
 } from './MarketingPreferencesDS.style';
 
 const CheckAnswer = ({
-  name, mpValidationOptions, userSelection, formContext
+  name, mpValidationOptions, userSelection = null, formContext = null
 }) => {
   const { setValue, clearErrors, register } = formContext;
 
@@ -61,11 +61,6 @@ const CheckAnswer = ({
       </CheckLabel>
     </CheckContainer>
   );
-};
-
-CheckAnswer.defaultProps = {
-  userSelection: null,
-  formContext: null
 };
 
 CheckAnswer.propTypes = {

--- a/src/components/Organisms/MarketingPreferencesDS/_MarketingPreferencesDS.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_MarketingPreferencesDS.js
@@ -15,11 +15,11 @@ import {
 } from './_MarketingPrefsConfig';
 
 const MarketingPreferencesDS = ({
-  copyTop,
-  copyBottom,
+  copyTop = defaultCopyTop,
+  copyBottom = defaultCopyBottom,
   mpValidationOptions,
-  id,
-  formContext
+  id = null,
+  formContext = null
 }) => {
   const { formState: { errors }, control } = formContext;
 
@@ -241,7 +241,7 @@ const MarketingPreferencesDS = ({
 };
 
 // removes from DOM completely
-const MaybeDisabled = ({ children, disabled }) => {
+const MaybeDisabled = ({ children = null, disabled = false }) => {
   if (disabled) return null;
   return children;
 };
@@ -256,21 +256,9 @@ MarketingPreferencesDS.propTypes = {
   formContext: PropTypes.shape()
 };
 
-MarketingPreferencesDS.defaultProps = {
-  copyTop: defaultCopyTop,
-  copyBottom: defaultCopyBottom,
-  id: null,
-  formContext: null
-};
-
 MaybeDisabled.propTypes = {
   children: PropTypes.node,
   disabled: PropTypes.bool
-};
-
-MaybeDisabled.defaultProps = {
-  children: null,
-  disabled: false
 };
 
 export {

--- a/src/components/Organisms/MarketingPreferencesDS/_TextInput.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_TextInput.js
@@ -4,7 +4,7 @@ import Input from '../../Atoms/Input/Input';
 
 const TextInput = ({
   fieldName, label,
-  optional, fieldType, formContext, ...rest
+  optional = null, fieldType = 'text', formContext = null, ...rest
 }) => {
   const { formState: { errors }, register } = formContext;
 
@@ -21,12 +21,6 @@ const TextInput = ({
   };
 
   return <Input {...props} {...register(fieldName)} />;
-};
-
-TextInput.defaultProps = {
-  optional: null,
-  fieldType: 'text',
-  formContext: null
 };
 
 TextInput.propTypes = {

--- a/src/components/Organisms/Membership/Form/Form.js
+++ b/src/components/Organisms/Membership/Form/Form.js
@@ -27,7 +27,7 @@ const Signup = ({
   data: { regularGiving },
   donateLink,
   otherDescription,
-  clientID,
+  clientID = 'the_fix',
   cartID,
   mbshipID,
   ...rest
@@ -204,8 +204,4 @@ Signup.propTypes = {
   data: PropTypes.objectOf(PropTypes.shape)
 };
 
-Signup.defaultProps = {
-  clientID: 'the_fix',
-  data: {}
-};
 export default Signup;

--- a/src/components/Organisms/Membership/Membership.js
+++ b/src/components/Organisms/Membership/Membership.js
@@ -8,19 +8,19 @@ import {
 } from './Membership.style';
 
 const Membership = ({
-  alt,
+  alt = '',
+  data = {},
+  formAligntRight = true,
+  imageLow = null,
+  image = null,
+  images = null,
+  backgroundColor = null,
+  mbshipID = null,
   cartID,
-  backgroundColor,
   donateLink,
-  data,
   title,
   subtitle,
-  otherDescription,
-  formAligntRight,
-  images,
-  image,
-  imageLow,
-  mbshipID
+  otherDescription
 }) => (
   <Container
     formAligntRight={formAligntRight}
@@ -72,14 +72,4 @@ Membership.propTypes = {
   mbshipID: PropTypes.string
 };
 
-Membership.defaultProps = {
-  alt: '',
-  data: {},
-  formAligntRight: true,
-  imageLow: null,
-  image: null,
-  images: null,
-  backgroundColor: null,
-  mbshipID: null
-};
 export default Membership;

--- a/src/components/Organisms/Membership/MoneyBox/MoneyBox.js
+++ b/src/components/Organisms/Membership/MoneyBox/MoneyBox.js
@@ -24,9 +24,9 @@ const MoneyBox = styled(Input)`
 
 const MoneyBuy = ({
   setOtherAmount,
-  amount,
-  currency,
-  description,
+  amount = '10',
+  currency = '£',
+  description = 'description',
   ...rest
 }) => (
   <MoneyBox
@@ -46,12 +46,6 @@ MoneyBuy.propTypes = {
   description: PropTypes.string,
   // Function already set does'nt need to be passed as props
   setOtherAmount: PropTypes.func.isRequired
-};
-
-MoneyBuy.defaultProps = {
-  amount: '10',
-  currency: '£',
-  description: 'description'
 };
 
 export default MoneyBuy;


### PR DESCRIPTION
### PR Titles
#### To pass testing pipeline, these need to follow Conventional Commits spec:
https://www.conventionalcommits.org/en/v1.0.0/
e.g.
`feat: create NewForm component`
or
`fix: update broken link in NewForm component`


### PR description
#### What is it doing?
Convert defaultProps to argument defaults to avoid console errors. It's difficult to spot *real* console errors in `react-payments` because of the `deaultProps` console errors.

#### Why is this required?
Recent versions of `react` have deprecated `defaultProps`. Even older versions of react allow argument defaults to be used instead of `defaultProps` so we can safely convert all our `defaultProps` to argument defaults.

#### link to Jira ticket:
...


### Quick Checklist:
- [ ] My PR title follows the Conventional Commit spec.

- [ ] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
