### PR TITLE
fix: DF-148 schools lookup refactor

### DIFF
--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -52,7 +52,6 @@ const TextInputWithDropdown = React.forwardRef(
         if (dropdownRef.current
           && !dropdownRef.current.contains(event.target)
           && !containerRef.current.contains(event.target)) {
-          console.log('clicked outside');
           setForceClosed(true);
           // Clear the input
           if (onChange) {

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import Input from '../Input/Input';
@@ -37,16 +37,43 @@ const TextInputWithDropdown = React.forwardRef(
       label,
       dropdownInstruction = null,
       className = '',
+      hideBorder = false,
       ...otherInputProps
     },
-    ref
+    forwardedRef
   ) => {
     const [activeOption, setActiveOption] = useState(-1);
     const [forceClosed, setForceClosed] = useState(false);
+    const dropdownRef = useRef(null);
+    const containerRef = useRef(null);
+
     useEffect(() => {
-      // reset if options change
-      setActiveOption(-1);
+      const handleClickOutside = event => {
+        if (dropdownRef.current
+          && !dropdownRef.current.contains(event.target)
+          && !containerRef.current.contains(event.target)) {
+          setForceClosed(true);
+          // Clear the input
+          if (onChange) {
+            onChange({ target: { value: '' } });
+          }
+        }
+      };
+
+      // Only add the listener if we have options showing
+      if (options.length > 0 && !forceClosed) {
+        document.addEventListener('mousedown', handleClickOutside);
+      }
+
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }, [options.length, forceClosed, onChange]);
+
+    // Reset forceClosed when options change
+    useEffect(() => {
       setForceClosed(false);
+      setActiveOption(-1);
     }, [options]);
 
     const down = () => (activeOption < options.length - 1
@@ -96,16 +123,19 @@ const TextInputWithDropdown = React.forwardRef(
       <Container
         className={`TextInputWithDropdown ${className}`.trim()}
         onKeyDown={navigateOptions}
+        ref={containerRef}
       >
         <Input
           {...inputProps}
           className="TextInputWithDropdown__input"
-          ref={ref}
+          ref={forwardedRef}
         />
-        {options.length > 0 && forceClosed === false && (
+        {options.length > 0 && !forceClosed && (
           <Options
             {...optionsProps}
             className="TextInputWithDropdown__options"
+            ref={dropdownRef}
+            hideBorder={hideBorder}
           />
         )}
       </Container>
@@ -183,7 +213,8 @@ TextInputWithDropdown.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   className: PropTypes.string,
-  dropdownInstruction: PropTypes.string
+  dropdownInstruction: PropTypes.string,
+  hideBorder: PropTypes.bool
 };
 
 Options.propTypes = {
@@ -191,7 +222,10 @@ Options.propTypes = {
   onSelect: PropTypes.func.isRequired,
   dropdownInstruction: PropTypes.string,
   activeOption: PropTypes.number.isRequired,
-  resetActiveOption: PropTypes.func.isRequired
+  resetActiveOption: PropTypes.func.isRequired,
+  hideBorder: PropTypes.bool
 };
+
+TextInputWithDropdown.displayName = 'TextInputWithDropdown';
 
 export default TextInputWithDropdown;

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -56,13 +56,15 @@ const TextInputWithDropdown = React.forwardRef(
         }
       };
 
-      // Only add the listener if we have options showing
+      // Only add the listeners if we have options showing
       if (options.length > 0 && !forceClosed) {
         document.addEventListener('mousedown', handleClickOutside);
+        document.addEventListener('touchstart', handleClickOutside);
       }
 
       return () => {
         document.removeEventListener('mousedown', handleClickOutside);
+        document.removeEventListener('touchstart', handleClickOutside);
       };
     }, [options.length, forceClosed, onChange]);
 

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -53,10 +53,6 @@ const TextInputWithDropdown = React.forwardRef(
           && !dropdownRef.current.contains(event.target)
           && !containerRef.current.contains(event.target)) {
           setForceClosed(true);
-          // Clear the input
-          if (onChange) {
-            onChange({ target: { value: '' } });
-          }
         }
       };
 

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -58,13 +58,11 @@ const TextInputWithDropdown = React.forwardRef(
 
       // Only add the listeners if we have options showing
       if (options.length > 0 && !forceClosed) {
-        document.addEventListener('mousedown', handleClickOutside);
-        document.addEventListener('touchstart', handleClickOutside);
+        ["mousedown", "touchstart"].forEach(event => document.addEventListener(event, handleClickOutside));
       }
 
       return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
-        document.removeEventListener('touchstart', handleClickOutside);
+        ["mousedown", "touchstart"].forEach(event => document. removeEventListener(event, handleClickOutside));
       };
     }, [options.length, forceClosed, onChange]);
 
@@ -152,6 +150,8 @@ const Options = React.forwardRef(({
   // Reset 'activeOption' when the list is unfocused.
   const onBlur = e => {
     const { target } = e;
+    // There's a delay before the new activeOption becomes the document.activeElement when
+    //  scrolling through the dropdown list via keyboard.
     setTimeout(() => {
       if (document.activeElement.parentNode !== target.parentNode) {
         resetActiveOption();

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -58,11 +58,11 @@ const TextInputWithDropdown = React.forwardRef(
 
       // Only add the listeners if we have options showing
       if (options.length > 0 && !forceClosed) {
-        ["mousedown", "touchstart"].forEach(event => document.addEventListener(event, handleClickOutside));
+        ['mousedown', 'touchstart'].forEach(event => document.addEventListener(event, handleClickOutside));
       }
 
       return () => {
-        ["mousedown", "touchstart"].forEach(event => document. removeEventListener(event, handleClickOutside));
+        ['mousedown', 'touchstart'].forEach(event => document.removeEventListener(event, handleClickOutside));
       };
     }, [options.length, forceClosed, onChange]);
 

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -52,6 +52,7 @@ const TextInputWithDropdown = React.forwardRef(
         if (dropdownRef.current
           && !dropdownRef.current.contains(event.target)
           && !containerRef.current.contains(event.target)) {
+          console.log('clicked outside');
           setForceClosed(true);
           // Clear the input
           if (onChange) {
@@ -143,19 +144,17 @@ const TextInputWithDropdown = React.forwardRef(
   }
 );
 
-const Options = ({
+const Options = React.forwardRef(({
   options,
   dropdownInstruction,
   onSelect,
   activeOption,
   resetActiveOption,
   ...rest
-}) => {
+}, ref) => {
   // Reset 'activeOption' when the list is unfocused.
   const onBlur = e => {
     const { target } = e;
-    // There's a delay before the new activeOption becomes the document.activeElement when
-    //  scrolling through the dropdown list via keyboard.
     setTimeout(() => {
       if (document.activeElement.parentNode !== target.parentNode) {
         resetActiveOption();
@@ -166,6 +165,7 @@ const Options = ({
   return (
     <Dropdown {...rest}>
       <DropdownList
+        ref={ref}
         role="listbox"
         onBlur={onBlur}
         aria-activedescendant={
@@ -203,7 +203,7 @@ const Options = ({
       </DropdownList>
     </Dropdown>
   );
-};
+});
 
 TextInputWithDropdown.propTypes = {
   options: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
@@ -16,7 +16,7 @@ const Dropdown = styled.div`
   max-height: 300px;
   overflow: auto;
   background-color: ${({ theme }) => theme.color('white')};
-  border: ${({ theme, hideBorder }) => (hideBorder ? 'none' : `1px solid ${theme.color('black')}`)};
+  border: ${({ theme, hideBorder }) => (hideBorder ? 'none' : `1px solid`)};
   margin-top: -1px;
   width: 100%;
 

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
@@ -16,7 +16,7 @@ const Dropdown = styled.div`
   max-height: 300px;
   overflow: auto;
   background-color: ${({ theme }) => theme.color('white')};
-  border: ${({ theme, hideBorder }) => (hideBorder ? 'none' : `1px solid`)};
+  border: ${({ hideBorder }) => (hideBorder ? 'none' : '1px solid')};
   margin-top: -1px;
   width: 100%;
 

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.style.js
@@ -16,7 +16,7 @@ const Dropdown = styled.div`
   max-height: 300px;
   overflow: auto;
   background-color: ${({ theme }) => theme.color('white')};
-  border: 1px solid;
+  border: ${({ theme, hideBorder }) => (hideBorder ? 'none' : `1px solid ${theme.color('black')}`)};
   margin-top: -1px;
   width: 100%;
 

--- a/src/components/Molecules/SchoolLookup/SchoolLookup.js
+++ b/src/components/Molecules/SchoolLookup/SchoolLookup.js
@@ -25,6 +25,7 @@ const SchoolLookup = React.forwardRef(
       dropdownInstruction = 'Please select a school from the list below',
       notFoundMessage = "Sorry, we can't find this school",
       onSelect,
+      hideBorder = false,
       ...rest
     },
     ref
@@ -39,6 +40,7 @@ const SchoolLookup = React.forwardRef(
       placeholder,
       notFoundMessage,
       dropdownInstruction,
+      hideBorder,
       ...rest
     };
 
@@ -52,7 +54,10 @@ SchoolLookup.propTypes = {
   label: PropTypes.string,
   placeholder: PropTypes.string,
   dropdownInstruction: PropTypes.string,
-  notFoundMessage: PropTypes.string
+  notFoundMessage: PropTypes.string,
+  hideBorder: PropTypes.bool
 };
+
+SchoolLookup.displayName = 'SchoolLookup';
 
 export default SchoolLookup;


### PR DESCRIPTION
### PR Titles
#### To pass testing pipeline, these need to follow Conventional Commits spec:
https://www.conventionalcommits.org/en/v1.0.0/
e.g.
`feat: create NewForm component`
or
`fix: update broken link in NewForm component`


### PR description
#### What is it doing?
There's a fixed black border around the schoolsLookup compo, and no close-on-click-outside behaviour. This fixes both.

#### Why is this required?
The donate FE rebuild doesn't need the border, and needs close on click outside.

#### link to Jira ticket:
[DF-148]



[DF-148]: https://comicrelief.atlassian.net/browse/DF-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ