### PR TITLE
fix: DF-130: Closes a dropdown list when the placeholder line is clicked

### DIFF
--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -66,7 +66,6 @@ const TextInputWithDropdown = React.forwardRef(
     }, [options.length, forceClosed, onChange]);
 
     const closeDropdown = () => {
-      console.log('handleDropdownInstructionClick');
       setForceClosed(true);
       setActiveOption(-1);
     };

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -7,7 +7,6 @@ import {
   Container,
   Dropdown,
   DropdownList,
-  DropdownItem,
   DropdownItemSelectable,
   TextItalic
 } from './TextInputWithDropdown.style';
@@ -66,6 +65,12 @@ const TextInputWithDropdown = React.forwardRef(
       };
     }, [options.length, forceClosed, onChange]);
 
+    const closeDropdown = () => {
+      console.log('handleDropdownInstructionClick');
+      setForceClosed(true);
+      setActiveOption(-1);
+    };
+
     // Reset forceClosed when options change
     useEffect(() => {
       setForceClosed(false);
@@ -112,6 +117,7 @@ const TextInputWithDropdown = React.forwardRef(
       onSelect,
       dropdownInstruction,
       activeOption,
+      closeDropdown,
       resetActiveOption: () => setActiveOption(-1)
     };
 
@@ -144,6 +150,7 @@ const Options = React.forwardRef(({
   dropdownInstruction,
   onSelect,
   activeOption,
+  closeDropdown,
   resetActiveOption,
   ...rest
 }, ref) => {
@@ -170,9 +177,16 @@ const Options = React.forwardRef(({
         }
       >
         {dropdownInstruction && (
-          <DropdownItem role="option">
-            <TextItalic>{dropdownInstruction}</TextItalic>
-          </DropdownItem>
+          <DropdownItemSelectable
+            id="dropdown-instruction"
+            role="option"
+            key="dropdown-instruction"
+            onClick={closeDropdown}
+          >
+            <TextItalic>
+              {dropdownInstruction}
+            </TextItalic>
+          </DropdownItemSelectable>
         )}
         {options.map((option, index) => (
           <DropdownItemSelectable
@@ -220,7 +234,8 @@ Options.propTypes = {
   dropdownInstruction: PropTypes.string,
   activeOption: PropTypes.number.isRequired,
   resetActiveOption: PropTypes.func.isRequired,
-  hideBorder: PropTypes.bool
+  hideBorder: PropTypes.bool,
+  closeDropdown: PropTypes.func.isRequired
 };
 
 TextInputWithDropdown.displayName = 'TextInputWithDropdown';

--- a/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
+++ b/src/components/Atoms/TextInputWithDropdown/TextInputWithDropdown.js
@@ -234,7 +234,7 @@ Options.propTypes = {
   activeOption: PropTypes.number.isRequired,
   resetActiveOption: PropTypes.func.isRequired,
   hideBorder: PropTypes.bool,
-  closeDropdown: PropTypes.func.isRequired
+  closeDropdown: PropTypes.func
 };
 
 TextInputWithDropdown.displayName = 'TextInputWithDropdown';


### PR DESCRIPTION
### PR description
#### What is it doing?
Bug DF-130 highlights that we have lost previous functionality, where dropdown lists (such as in the postcode lookup) should close results if you click the first descriptive placeholder line that appears at the top of the results, such as 'Please select a school'

#### Why is this required?
Keep app behaviour consistent.

#### link to Jira ticket:
[DF-130]


### Quick Checklist:
- [ ] My PR title follows the Conventional Commit spec.

- [ ] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[DF-130]: https://comicrelief.atlassian.net/browse/DF-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ