### PR TITLE
fix: use all available space for More Nav item

### DIFF
--- a/src/components/Atoms/SocialIcons/Icon/Icon.js
+++ b/src/components/Atoms/SocialIcons/Icon/Icon.js
@@ -53,7 +53,7 @@ const StyledLink = styled.a`
         }
   
         // Tweak for Shop's shorter text:
-        &[data-testid="header-shop"] {
+        &[data-test="header-shop"] {
           padding-right: 48px;
         }
         

--- a/src/components/Atoms/SocialIcons/Icon/Icon.js
+++ b/src/components/Atoms/SocialIcons/Icon/Icon.js
@@ -48,7 +48,7 @@ const StyledLink = styled.a`
         padding-right: ${RevealTextWidth}px;
   
         // Tweak for ESU's longer text:
-        &[data-testid="header-esu"] {
+        &[data-test="header-esu"] {
           padding-right: 92px;
         }
   

--- a/src/components/Organisms/Header2025/HeaderNav2025/MoreNav.style.js
+++ b/src/components/Organisms/Header2025/HeaderNav2025/MoreNav.style.js
@@ -59,7 +59,7 @@ const MoreNavItem = styled(NavItem)`
     margin-left: 22px;
     // Let it take up all the space to be a bigger target:
     display: flex;
-    flex-grow: 0.5;
+    flex-grow: 1;
 
     // Chevron icon:
     ${MoreNavLabel} > ${ChevronWrapper} {


### PR DESCRIPTION
Turns out this flew-grow width DOES work _dynamically_, so it won't interfere with the header icon hover width animation stuff.