### PR TITLE
fix: associate checkboxes with their labels as tests can't target hidden checkboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Install Playwright:
 yarn playwright install
 ```
 
-Run the tests
+Run the tests:
 ```
 yarn test:e2e:local
 ```

--- a/playwright/components/atoms/checkbox.spec.js
+++ b/playwright/components/atoms/checkbox.spec.js
@@ -51,7 +51,7 @@ test.describe('checkbox', () => {
 
     // football checkbox
     await page.locator('[data-testid="Checkbox-example-1"] div > label:nth-child(5)').click();
-    await expect(page.locator('[data-testid="Checkbox-example-1"] div > label:nth-child(5)')).toHaveValue('Football');
+    await expect(page.locator('[data-testid="Checkbox-example-1"] div > label:nth-child(5)')).toHaveValue('Football (with wacky styling to test props)');
     expect(await page.locator('[data-testid="Checkbox-example-1"] div > label:nth-child(5)').isChecked()).toBeFalsy();
 
     // terms and conditions

--- a/playwright/components/atoms/checkbox.spec.js
+++ b/playwright/components/atoms/checkbox.spec.js
@@ -1,8 +1,7 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('checkbox', () => {
-  test('checkbox component', async ({ page }) => {
-
+  test.only('checkbox component', async ({ page }) => {
     await page.goto('/#checkbox');
 
     // checkbox component should be visible
@@ -27,7 +26,7 @@ test.describe('checkbox', () => {
 
     // football checkbox
     await page.locator('[data-testid="Checkbox-example-1"] div > label:nth-child(5)').click();
-    await expect(page.locator('[data-testid="Checkbox-example-1"] div > label:nth-child(5)')).toHaveValue('Football');
+    await expect(page.locator('[data-testid="Checkbox-example-1"] div > label:nth-child(5)')).toHaveValue('Football (with wacky styling to test props)');
     expect(await page.locator('[data-testid="Checkbox-example-1"] div > label:nth-child(5)').isChecked()).toBeTruthy();
 
     // terms and conditions

--- a/playwright/components/atoms/checkbox.spec.js
+++ b/playwright/components/atoms/checkbox.spec.js
@@ -1,7 +1,7 @@
 const { test, expect } = require('@playwright/test');
 
 test.describe('checkbox', () => {
-  test.only('checkbox component', async ({ page }) => {
+  test('checkbox component', async ({ page }) => {
     await page.goto('/#checkbox');
 
     // checkbox component should be visible

--- a/src/components/Atoms/Checkbox/Checkbox.md
+++ b/src/components/Atoms/Checkbox/Checkbox.md
@@ -30,8 +30,8 @@ const LongLabel = () => (
     <Checkbox
         id="sport4"
         name="sport4"
-        value="Football"
-        label="Tennis (with wacky styling to test props)"
+        value="Football (with wacky styling to test props)"
+        label="Football (with wacky styling to test props)"
         labelColour="purple_dark"
         checkboxBg="white"
         checkboxBorder="black"
@@ -41,7 +41,7 @@ const LongLabel = () => (
     />
     <br/>
     <p>A checkbox with a long label containing links</p>
-    <Checkbox name="node_label" value="node_label">
+    <Checkbox id="node_label" name="node_label" value="node_label">
       <LongLabel />
     </Checkbox>
 </>


### PR DESCRIPTION
Accidentally pushed to master midway, rather than a PR branch; fixing here it now.