### PR TITLE
fix: fixes footer 'allowlist' override

### DIFF
--- a/src/components/Organisms/Footer/Footer.js
+++ b/src/components/Organisms/Footer/Footer.js
@@ -23,7 +23,7 @@ const Footer = ({
 
   return (
     <div>
-      <FooterWrapper overrideallowList={overrideallowList} navItems {...rest}>
+      <FooterWrapper navItems {...rest}>
         <InnerWrapper>
           {additionalLegalLine
             && <FooterLegalLine tag="p" color="grey">{additionalLegalLine}</FooterLegalLine>
@@ -36,7 +36,7 @@ const Footer = ({
               <Logo sizeSm="48px" sizeMd="72px" rotate={false} campaign={campaign} />
             </Brand>
           </FooterBranding>
-          <FooterNav navItems={navItems} {...rest} />
+          <FooterNav navItems={navItems} overrideallowList={overrideallowList} {...rest} />
           <FooterCopyright>
             <Text tag="p" color="grey">
               {footerCopy}


### PR DESCRIPTION
Looks like someone previously put that prop in the wrong place...

This **_now_** allows us to completely ignore the allowlist (which governs internal vs. external footer links) so Donate can mark every CRcom footer link as 'external', opening in a new tab