### PR TITLE
fix: DF-375 fixes marketing prefs font size and alignment

### DIFF
--- a/src/components/Organisms/MarketingPreferencesDS/MarketingPreferencesDS.style.js
+++ b/src/components/Organisms/MarketingPreferencesDS/MarketingPreferencesDS.style.js
@@ -23,7 +23,7 @@ const OuterWrapper = styled.div`
     height: 0;
     overflow: hidden;
     z-index: -1;
-    content: 
+    content:
       url(${EmailIconWhite})
       url(${PhoneIconWhite})
       url(${PostIconWhite})
@@ -43,6 +43,7 @@ const TopCopyWrapper = styled.div`
 
 const BottomCopyWrapper = styled.div`
   margin: ${spacing('md')} 0;
+  text-align: center;
 `;
 
 const CheckboxWrapper = styled.div`

--- a/src/components/Organisms/MarketingPreferencesDS/_DefaultCopy.js
+++ b/src/components/Organisms/MarketingPreferencesDS/_DefaultCopy.js
@@ -18,7 +18,7 @@ const defaultCopyTop = (
 );
 
 const defaultCopyBottom = (
-  <Text tag="p" color="grey_dark">
+  <Text tag="p" size="xs" color="grey_dark">
     Update your preferences at any time by visiting our
     {' '}
     <Link


### PR DESCRIPTION

### PR description
#### What is it doing?
Amends some marketing preferences copy from 16px > 12px, and aligns to center, to match Figma designs

#### Why is this required?
Design QA feedback

#### link to Jira ticket:
[DF-375]

[DF-375]: https://comicrelief.atlassian.net/browse/DF-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ