### PR TITLE
Revert "feat: use CSS support over crummy feat-scraping in Picture"

### DIFF
--- a/src/components/Atoms/Picture/Picture.js
+++ b/src/components/Atoms/Picture/Picture.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { css, withTheme } from 'styled-components';
 import PropTypes from 'prop-types';
 import spacing from '../../../theme/shared/spacing';
@@ -10,39 +10,22 @@ import 'lazysizes/plugins/blur-up/ls.blur-up';
 const IMAGE_FALLBACK = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 const Wrapper = styled.div`
-  // If this browser doesn't support objectFit:
-  ${({ nonObjFitImage }) => (nonObjFitImage)
-  && `@supports not ((object-fit: cover) or (object-fit: none) or (object-fit: contain)) {
-        background-image: url(${nonObjFitImage});
-        background-size: cover;
-        background-position: center;
-      }
-  `};
-
+  ${({ objFitState, nonObjFitImage }) => (!objFitState && nonObjFitImage) && `background-image: url(${nonObjFitImage}); background-size: cover; background-position: center;`};
   display: block;
   width: ${props => (props.width ? props.width : '100%')};
   height: ${props => (props.height ? props.height : '100%')};
   position: relative;
-
-  ${({ isBackgroundImage }) => isBackgroundImage
-    && 'position: absolute; bottom: 0px; left: 0px; right: 0px; height: 100%;'};
+  ${({ isBackgroundImage }) => isBackgroundImage && 'position: absolute; bottom: 0px; left: 0px; right: 0px; height: 100%;'};
   `;
 
 const Image = styled.img`
   width: ${props => (props.width ? props.width : '100%')};
   height: ${props => (props.height ? props.height : 'auto')};
   display: block;
-
   object-fit: ${props => (props.objectFit === 'none' && 'none')
     || (props.objectFit === 'cover' && 'cover')
     || (props.objectFit === 'contain' && 'contain')};
-
-  // If this browser doesn't support objectFit:
-  ${({ objectFit }) => (objectFit !== 'none')
-    && `@supports not ((object-fit: cover) or (object-fit: contain)) {
-      visibility: hidden;
-    `}
-    // Allows image to provide the container height, but make it invisible
+  ${({ objectFit, objFitState }) => (objectFit !== 'none' && !objFitState) && 'visibility: hidden;'}; // Allows image to provide the container height, but make it invisible
 
   /* Check for Cards/smallBreakpointRowLayout prop coming from the CMS and adjust styling for row view */
   ${({ smallBreakpointRowLayout }) => (smallBreakpointRowLayout === true) && css`
@@ -77,6 +60,7 @@ const Image = styled.img`
         height: ${props => (props.height ? props.height : 'auto')};
       }
   `}
+
 `;
 
 /** Responsive Picture */
@@ -93,7 +77,16 @@ const Picture = ({
   mediumBreakpointRowLayout = null,
   ...rest
 }) => {
+  const document = typeof window !== 'undefined' ? window.document : null;
+  const [objFitState, setObjFitState] = useState(true);
   let nonObjFitImage = null;
+
+  useEffect(() => {
+    // Once document is available, determine if this browser supports object-fit
+    if ('objectFit' in document.documentElement.style === false) {
+      setObjFitState(false);
+    }
+  }, [document]);
 
   // Determine which image will be used for the nonObjectFit fallback
   if (image) {
@@ -111,6 +104,7 @@ const Picture = ({
         images={images}
         isBackgroundImage={isBackgroundImage}
         nonObjFitImage={nonObjFitImage}
+        objFitState={objFitState}
         {...rest}
       >
         <Image
@@ -120,6 +114,7 @@ const Picture = ({
           objectFit={objectFit}
           data-src={image}
           className="lazyload"
+          objFitState={objFitState}
         />
       </Wrapper>
     );
@@ -131,9 +126,11 @@ const Picture = ({
       width={width}
       image={image}
       images={images}
+      setObjFitState={setObjFitState}
       className="lazyload"
       isBackgroundImage={isBackgroundImage}
       nonObjFitImage={nonObjFitImage}
+      objFitState={objFitState}
       {...rest}
     >
       <Image
@@ -148,6 +145,7 @@ const Picture = ({
         data-sizes="auto"
         data-lowsrc={imageLow}
         className="lazyload"
+        objFitState={objFitState}
         smallBreakpointRowLayout={smallBreakpointRowLayout}
         mediumBreakpointRowLayout={mediumBreakpointRowLayout}
       />

--- a/src/components/Atoms/Picture/Picture.test.js
+++ b/src/components/Atoms/Picture/Picture.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import 'jest-styled-components';
-import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
-import Picture from './Picture';
-import { defaultData } from '../../../styleguide/data/data';
-it('renders correctly', () => {
+import React from "react";
+import "jest-styled-components";
+import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
+import Picture from "./Picture";
+import { defaultData } from "../../../styleguide/data/data";
+it("renders correctly", () => {
   const tree = renderWithTheme(
     <Picture
       images={defaultData.images}
@@ -27,14 +27,6 @@ it('renders correctly', () => {
       object-fit: none;
     }
 
-    @supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-      .c0 {
-        background-image: url(http://images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-        background-size: cover;
-        background-position: center;
-      }
-    }
-
     <div
       className="c0 lazyload"
       height="auto"
@@ -56,7 +48,7 @@ it('renders correctly', () => {
   `);
 });
 
-it('renders correctly with custom props', () => {
+it("renders correctly with custom props", () => {
   const tree = renderWithTheme(
     <Picture
       images={defaultData.images}
@@ -81,20 +73,6 @@ it('renders correctly with custom props', () => {
       height: 100px;
       display: block;
       object-fit: cover;
-    }
-
-    @supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-      .c0 {
-        background-image: url(http://images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-        background-size: cover;
-        background-position: center;
-      }
-    }
-
-    @supports not ((object-fit:cover) or (object-fit:contain)) {
-      .c1 {
-        visibility: hidden;
-      }
     }
 
     <div

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -154,20 +154,6 @@ it('renders article teaser correctly', () => {
       display: flex;
     }
 
-    @supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-      .c4 {
-        background-image: url(http://images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-        background-size: cover;
-        background-position: center;
-      }
-    }
-
-    @supports not ((object-fit:cover) or (object-fit:contain)) {
-      .c6 {
-        visibility: hidden;
-      }
-    }
-
     @media (min-width:740px) {
       .c2 {
         -webkit-flex-direction: row;
@@ -423,20 +409,6 @@ it('renders press realese correctly', () => {
       display: -webkit-flex;
       display: -ms-flexbox;
       display: flex;
-    }
-
-    @supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-      .c4 {
-        background-image: url(mock.asset);
-        background-size: cover;
-        background-position: center;
-      }
-    }
-
-    @supports not ((object-fit:cover) or (object-fit:contain)) {
-      .c6 {
-        visibility: hidden;
-      }
     }
 
     @media (min-width:740px) {

--- a/src/components/Molecules/Card/__snapshots__/Card.test.js.snap
+++ b/src/components/Molecules/Card/__snapshots__/Card.test.js.snap
@@ -189,12 +189,6 @@ exports[`renders correctly with no body 1`] = `
   height: auto;
 }
 
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c3 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:0px) {
   .c0 {
     -webkit-flex-direction: column;

--- a/src/components/Molecules/CardDs/__snapshots__/CardDs.test.js.snap
+++ b/src/components/Molecules/CardDs/__snapshots__/CardDs.test.js.snap
@@ -119,20 +119,6 @@ exports[`renders Column view correctly 1`] = `
   z-index: 2;
 }
 
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c3 {
-    background-image: url(//images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c4 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
   .c8 {
     width: auto;
@@ -389,20 +375,6 @@ exports[`renders correctly 1`] = `
   right: 3.5rem;
   bottom: -1.5rem;
   z-index: 2;
-}
-
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c3 {
-    background-image: url(//images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c4 {
-    visibility: hidden;
-  }
 }
 
 @media (min-width:740px) {

--- a/src/components/Molecules/PartnerLink/PartnerLink.test.js
+++ b/src/components/Molecules/PartnerLink/PartnerLink.test.js
@@ -116,14 +116,6 @@ it('renders correctly', () => {
       background-color: #E52630;
     }
 
-    @supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-      .c2 {
-        background-image: url(//images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-        background-size: cover;
-        background-position: center;
-      }
-    }
-
     @media (min-width:740px) {
       .c6 {
         font-size: 1rem;

--- a/src/components/Molecules/Promo/__snapshots__/Promo.test.js.snap
+++ b/src/components/Molecules/Promo/__snapshots__/Promo.test.js.snap
@@ -153,20 +153,6 @@ exports[`renders Promo correctly 1`] = `
   }
 }
 
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c2 {
-    background-image: url(../promo.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c3 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
   .c9 {
     width: auto;
@@ -442,20 +428,6 @@ exports[`renders Promo correctly end position 1`] = `
     font-size: 5rem;
     line-height: 5rem;
     margin-bottom: 2rem;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c2 {
-    background-image: url(../promo.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c3 {
-    visibility: hidden;
   }
 }
 

--- a/src/components/Molecules/SearchResult/__snapshots__/SearchResult.test.js.snap
+++ b/src/components/Molecules/SearchResult/__snapshots__/SearchResult.test.js.snap
@@ -97,12 +97,6 @@ exports[`renders correctly in minimalist form 1`] = `
   margin: 0;
 }
 
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c5 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
   .c2 {
     -webkit-flex-direction: row;
@@ -285,12 +279,6 @@ exports[`renders correctly with copy 1`] = `
   }
 }
 
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c5 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
   .c2 {
     -webkit-flex-direction: row;
@@ -464,12 +452,6 @@ exports[`renders correctly with date 1`] = `
   margin: 0;
 }
 
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c5 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
   .c2 {
     -webkit-flex-direction: row;
@@ -635,12 +617,6 @@ exports[`renders correctly with date and type 1`] = `
 
 .c9 {
   margin: 0;
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c5 {
-    visibility: hidden;
-  }
 }
 
 @media (min-width:740px) {

--- a/src/components/Molecules/SingleMessage/__snapshots__/SingleMessage.test.js.snap
+++ b/src/components/Molecules/SingleMessage/__snapshots__/SingleMessage.test.js.snap
@@ -65,20 +65,6 @@ exports[`renders Single Message with 100% vertical height image correctly 1`] = 
   z-index: 1;
 }
 
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c3 {
-    background-image: url(http://images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c4 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
   .c0 {
     -webkit-flex-direction: row;
@@ -292,20 +278,6 @@ exports[`renders Single Message with Image correctly 1`] = `
   z-index: 1;
 }
 
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c3 {
-    background-image: url(http://images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c4 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
   .c8 {
     width: auto;
@@ -508,20 +480,6 @@ exports[`renders Single Message with double image correctly 1`] = `
   height: 100%;
   height: 50%;
   z-index: 1;
-}
-
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c3 {
-    background-image: url(http://images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c4 {
-    visibility: hidden;
-  }
 }
 
 @media (min-width:740px) {
@@ -778,20 +736,6 @@ exports[`renders Single Message with full width correctly 1`] = `
   z-index: 1;
 }
 
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c3 {
-    background-image: url(http://images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c4 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
   .c8 {
     width: auto;
@@ -996,20 +940,6 @@ exports[`renders Single Message with full width image and no text correctly 1`] 
   z-index: 1;
 }
 
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c3 {
-    background-image: url(http://images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c4 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
 
 }
@@ -1134,14 +1064,6 @@ exports[`renders Single Message with no Image correctly 1`] = `
   padding: 2rem;
   margin: auto;
   padding: 1rem;
-}
-
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-
 }
 
 @media (min-width:740px) {

--- a/src/components/Molecules/SingleMessageDS/__snapshots__/SingleMessageDs.test.js.snap
+++ b/src/components/Molecules/SingleMessageDS/__snapshots__/SingleMessageDs.test.js.snap
@@ -153,20 +153,6 @@ exports[`renders correctly 1`] = `
   right: 1.5rem;
 }
 
-@supports not ((object-fit:cover) or (object-fit:none) or (object-fit:contain)) {
-  .c3 {
-    background-image: url(//images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg);
-    background-size: cover;
-    background-position: center;
-  }
-}
-
-@supports not ((object-fit:cover) or (object-fit:contain)) {
-  .c4 {
-    visibility: hidden;
-  }
-}
-
 @media (min-width:740px) {
   .c12 {
     width: auto;

--- a/src/components/Organisms/Membership/Membership.test.js
+++ b/src/components/Organisms/Membership/Membership.test.js
@@ -339,12 +339,6 @@ it('renders correctly', () => {
       background-color: #961D35;
     }
 
-    @supports not ((object-fit:cover) or (object-fit:contain)) {
-      .c3 {
-        visibility: hidden;
-      }
-    }
-
     @media (min-width:740px) {
 
     }


### PR DESCRIPTION
Reverts comicrelief/component-library#734

This seems to have brought about undesired knock-on effects and didn't even solve what I hoped it would