### PR TITLE
feat: Changes default accordion text style from h3 to h4, and allows overriding via props

### DIFF
--- a/src/components/Molecules/Accordion/Accordion.js
+++ b/src/components/Molecules/Accordion/Accordion.js
@@ -79,7 +79,7 @@ const StyledText = styled(Text)`
 `;
 
 const Accordion = ({
-  children, title, contentBottomPadding, ...rest
+  children, title, contentBottomPadding, textTag = 'h4', weight, ...rest
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -90,7 +90,7 @@ const Accordion = ({
   return (
     <Container {...rest}>
       <Button onClick={handleOpen} aria-expanded={isOpen ? 'true' : 'false'} ChevronKeyframes={ChevronKeyframes} type="button">
-        <StyledText tag="h3">
+        <StyledText tag={textTag} weight={weight}>
           {title}
         </StyledText>
         <Icon>
@@ -106,6 +106,8 @@ const Accordion = ({
 
 Accordion.propTypes = {
   contentBottomPadding: PropTypes.string,
+  weight: PropTypes.string,
+  textTag: PropTypes.string,
   children: PropTypes.node.isRequired,
   title: PropTypes.oneOfType([
     PropTypes.string,

--- a/src/components/Molecules/Accordion/Accordion.md
+++ b/src/components/Molecules/Accordion/Accordion.md
@@ -33,3 +33,19 @@ import Text from '../../Atoms/Text/Text';
   </Text>
 </Accordion>
 ```
+
+```js
+import Text from '../../Atoms/Text/Text';
+
+<Accordion
+  contentBottomPadding="100px"
+  title={
+    <Text textTag="p" weight="700">
+      I am a title with an overridden text type and weight, to 'p' 700 which is the new donate preference
+    </Text>
+  }
+  >
+  
+  <Text tag="p" size="s">lorem ipsum</Text>
+</Accordion>
+```

--- a/src/components/Molecules/Accordion/__snapshots__/Accordion.test.js.snap
+++ b/src/components/Molecules/Accordion/__snapshots__/Accordion.test.js.snap
@@ -9,8 +9,8 @@ exports[`renders correctly 1`] = `
   -moz-letter-spacing: 0;
   -ms-letter-spacing: 0;
   letter-spacing: 0;
-  font-size: 1.25rem;
-  line-height: 1.5rem;
+  font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c2 span {
@@ -141,15 +141,15 @@ exports[`renders correctly 1`] = `
 
 @media (min-width:740px) {
   .c2 {
-    font-size: 1.25rem;
-    line-height: 1.5rem;
+    font-size: 1rem;
+    line-height: 1.25rem;
   }
 }
 
 @media (min-width:1024px) {
   .c2 {
-    font-size: 1.375rem;
-    line-height: 1.625rem;
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -208,7 +208,7 @@ exports[`renders correctly 1`] = `
     onClick={[Function]}
     type="button"
   >
-    <h3
+    <h4
       className="c2 c3"
     >
       <h2
@@ -216,7 +216,7 @@ exports[`renders correctly 1`] = `
       >
         I am the title
       </h2>
-    </h3>
+    </h4>
     <div
       className="c5"
     >


### PR DESCRIPTION
### PR description
#### What is it doing?
The default accordion title text type needs to be changed from an h3 to h4.
However for new donate, we've got 2 instances where Curtis believes bold 'p' would look better. To handle these cases, the accordion now allows prop overrides for the text tag and weight.

#### Why is this required?
New donate visual fixes.

#### link to Jira ticket:
[ENG-4980]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-4980]: https://comicrelief.atlassian.net/browse/ENG-4980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ