### PR TITLE
fix: Unset `children` as required prop to ButtonWithStates

### DIFF
--- a/src/components/Atoms/ButtonWithStates/ButtonWithStates.js
+++ b/src/components/Atoms/ButtonWithStates/ButtonWithStates.js
@@ -49,7 +49,7 @@ const ButtonWithStates = React.forwardRef(({
 });
 
 ButtonWithStates.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   loadingText: PropTypes.string,
   loading: PropTypes.bool,
   disabled: PropTypes.bool

--- a/src/components/Atoms/ButtonWithStates/ButtonWithStates.md
+++ b/src/components/Atoms/ButtonWithStates/ButtonWithStates.md
@@ -11,3 +11,13 @@ import ButtonWithStates from './ButtonWithStates';
   Enter prize draw
 </ButtonWithStates>
 ```
+
+## Optional prop `children`
+
+`children` is an optional prop, this example demonstrates the button will not error without any provided.
+
+```js
+import ButtonWithStates from './ButtonWithStates';
+
+<ButtonWithStates type="submit" loading loadingText="Submitting…" />
+```


### PR DESCRIPTION
### PR description
#### What is it doing?
<img width="730" height="388" alt="image" src="https://github.com/user-attachments/assets/bf7c4efc-850c-45cc-9fa9-76ba576e235c" />

We're seeing this error regularly in new donate, on the payment select page.
I'm pretty sure it's because Paypal just isn't providing anything until it's ready. In that brief window of time, our `ButtonWithStates` component is getting upset at not having any children supplied.

#### Why is this required?
Console cleanup

#### link to Jira ticket:
No ticket


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
