### PR TITLE
fix: In mobile view, moves the play pause button to the top left

### DIFF
--- a/src/components/Atoms/AmbientVideo/AmbientVideo.style.js
+++ b/src/components/Atoms/AmbientVideo/AmbientVideo.style.js
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 
+import { breakpointValues } from '../../../theme/shared/allBreakpoints';
 import zIndex from '../../../theme/shared/zIndex';
+
+const mobileMaxWidth = breakpointValues.L - 1;
 
 const Wrapper = styled.div`
   width: 100%;
@@ -79,12 +82,19 @@ const PlayPauseButton = styled.button`
   justify-content: center;
   opacity: 0;
   transition: opacity 0.2s ease 2s;
-  ${zIndex('high')};
 
   // Play icon is shifted to the right slightly as it
   // doesn't look quite right when centered normally
   &[data-play-pause='play'] ${PlayPauseIcon} {
     transform: translateX(2px);
+  }
+
+  // Play icon needs to go to the top left on mobile
+  // as with the hero banner, the text container can
+  // overlap it
+  @media (max-width: ${mobileMaxWidth}px) {
+    top: 15px;
+    bottom: auto;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/components/Atoms/AmbientVideo/AmbientVideo.style.js
+++ b/src/components/Atoms/AmbientVideo/AmbientVideo.style.js
@@ -1,9 +1,6 @@
 import styled, { keyframes } from 'styled-components';
 
-import { breakpointValues } from '../../../theme/shared/allBreakpoints';
 import zIndex from '../../../theme/shared/zIndex';
-
-const mobileMaxWidth = breakpointValues.L - 1;
 
 // This is so that the button is initially visible, then afterwards
 // it's only seen again on hover
@@ -80,7 +77,8 @@ const PlayPauseIcon = styled.span`
 
 const PlayPauseButton = styled.button`
   position: absolute;
-  bottom: 15px;
+  top: 15px;
+  bottom: auto;
   left: 15px;
   width: 35px;
   height: 35px;
@@ -105,10 +103,11 @@ const PlayPauseButton = styled.button`
 
   // Play icon needs to go to the top left on mobile
   // as with the hero banner, the text container can
-  // overlap it
-  @media (max-width: ${mobileMaxWidth}px) {
-    top: 15px;
-    bottom: auto;
+  // overlap it. Here in desktop view it can come
+  // back to the bottom.
+  @media ${({ theme }) => theme.allBreakpoints('L')} {
+    bottom: 15px;
+    top: auto;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
+++ b/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
@@ -40,7 +40,8 @@ exports[`renders AmbientVideo when video props are provided correctly 1`] = `
 
 .c6 {
   position: absolute;
-  bottom: 15px;
+  top: 15px;
+  bottom: auto;
   left: 15px;
   width: 35px;
   height: 35px;
@@ -94,10 +95,10 @@ exports[`renders AmbientVideo when video props are provided correctly 1`] = `
   }
 }
 
-@media (max-width:1023px) {
+@media (min-width:1024px) {
   .c6 {
-    top: 15px;
-    bottom: auto;
+    bottom: 15px;
+    top: auto;
   }
 }
 

--- a/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
+++ b/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
@@ -94,6 +94,13 @@ exports[`renders AmbientVideo when video props are provided correctly 1`] = `
   }
 }
 
+@media (max-width:1023px) {
+  .c6 {
+    top: 15px;
+    bottom: auto;
+  }
+}
+
 @media (prefers-reduced-motion:reduce) {
   .c6 {
     display: none;


### PR DESCRIPTION
### PR description
#### What is it doing?
In mobile view, moves the play/pause button from the bottom left to the top left.

#### Why is this required?
Design QA: Without this, the button is overlapped by the hero banner's text

#### link to Jira ticket:
[ENG-5005]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5005]: https://comicrelief.atlassian.net/browse/ENG-5005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ