### PR TITLE
fix: Amends mistake in ESU_FIELDS.LAST_NAME validation

### DIFF
--- a/src/components/Organisms/shared/emailSignup/emailSignupConfig.js
+++ b/src/components/Organisms/shared/emailSignup/emailSignupConfig.js
@@ -45,7 +45,7 @@ const buildEsuValidationSchema = overrides => {
         /^[A-Za-z][A-Za-z' -]*$/,
         "This field only accepts letters and ' - and must start with a letter"
       )
-      .max(50, 'Your first name must be between 1 and 50 characters'),
+      .max(50, 'Your last name must be between 1 and 50 characters'),
     [ESU_FIELDS.EMAIL]: yup
       .string()
       .required('Please enter your email address')


### PR DESCRIPTION
### PR description
#### What is it doing?
Bug spotted where a failure in Last Name validation refers to the 'first name' of the user rather than last name.

#### Why is this required?
Bugfix

#### link to Jira ticket:
[ENG-5015]


### Quick Checklist:
- [ ] My PR title follows the Conventional Commit spec.

- [ ] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5015]: https://comicrelief.atlassian.net/browse/ENG-5015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ