### PR TITLE
feat: ENG-4396 padding options on WYMD + RichText carousels

### DIFF
--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.js
@@ -7,23 +7,26 @@ import {
 } from 'pure-react-carousel';
 import 'pure-react-carousel/dist/react-carousel.es.css';
 import {
-  CarouselWrapper, SlideCopyWrapper, HeadingCopyWrapper
+  CarouselWrapper, SlideCopyWrapper, HeadingCopyWrapper, Container
 } from './RichtextCarousel.style';
 import { breakpointValues } from '../../../theme/shared/allBreakpoints';
 
 const RichtextCarousel = ({
   data: {
-    contentful_id: thisID,
     autoPlay,
-    nodes,
+    contentful_id: thisID,
     headingCopy,
+    nodes,
     // Set some defaults for good measure:
+    carouselBackgroundColour = 'white',
+    desktopHeight = 350,
     mobileHeight = 300,
     tabletHeight = 350,
-    desktopHeight = 350,
-    carouselBackgroundColour = 'white',
     nodeBackgroundColour = 'white',
-    nodeOutlineColour = 'grey'
+    nodeOutlineColour = 'grey',
+    paddingBottom = '2rem',
+    paddingTop = '2rem',
+    rowBackgroundColour = 'grey_light'
   }
 }) => {
   // Defaults to mobile config:
@@ -67,76 +70,84 @@ const RichtextCarousel = ({
   }
 
   return (
-    <CarouselWrapper
-      className="CarouselWrapper"
-      id={thisID}
-      mobileHeight={mobileHeight}
-      tabletHeight={tabletHeight}
-      desktopHeight={desktopHeight}
-      carouselBackgroundColour={carouselBackgroundColour}
+    <Container
+      paddingTop={paddingTop}
+      paddingBottom={paddingBottom}
+      rowBackgroundColour={rowBackgroundColour}
     >
 
-      <HeadingCopyWrapper>
-        {headingCopy}
-      </HeadingCopyWrapper>
-
-      {theseItems && (
-      <CarouselProvider
-        naturalSlideWidth={50}
-        naturalSlideHeight={200}
-        totalSlides={totalSlides}
-        isPlaying={autoPlay}
-        interval={5000}
-        visibleSlides={visibleSlides}
-        infinite
+      <CarouselWrapper
+        className="CarouselWrapper"
+        id={thisID}
+        mobileHeight={mobileHeight}
+        tabletHeight={tabletHeight}
+        desktopHeight={desktopHeight}
+        carouselBackgroundColour={carouselBackgroundColour}
       >
-        <Slider classNameAnimation="richtext-carousel">
 
-          {/* Dummy slide for our desired non-mobile layout and functionality */}
-          {isMobile === false && (
-          <Slide index={0} key={0} />
-          )}
+        <HeadingCopyWrapper>
+          {headingCopy}
+        </HeadingCopyWrapper>
 
-          {Object.keys(theseItems).map((key, index) => {
+        {theseItems && (
+        <CarouselProvider
+          naturalSlideWidth={50}
+          naturalSlideHeight={200}
+          totalSlides={totalSlides}
+          isPlaying={autoPlay}
+          interval={5000}
+          visibleSlides={visibleSlides}
+          infinite
+        >
+          <Slider classNameAnimation="richtext-carousel">
+
+            {/* Dummy slide for our desired non-mobile layout and functionality */}
+            {isMobile === false && (
+            <Slide index={0} key={0} />
+            )}
+
+            {Object.keys(theseItems).map((key, index) => {
             // Reflect that initial dummy/bookend slide shown on non-mobile/tablet views:
-            const thisOffsetIndex = index + (isMobile ? 0 : 1);
+              const thisOffsetIndex = index + (isMobile ? 0 : 1);
 
-            return (
+              return (
               // Calculate the index offset accordingly to reflect the number of slides,
               // but use the REAL index when determining if its the last REAL slide
-              <Slide
-                index={thisOffsetIndex}
-                className={index === (theseItems.length - 1) && 'last-slide'}
-                key={thisOffsetIndex}
-              >
-
-                <SlideCopyWrapper
-                  className="slide-copy-wrapper"
-                  mobileHeight={mobileHeight}
-                  tabletHeight={tabletHeight}
-                  desktopHeight={desktopHeight}
-                  nodeBackgroundColour={nodeBackgroundColour}
-                  nodeOutlineColour={nodeOutlineColour}
+                <Slide
+                  index={thisOffsetIndex}
+                  className={index === (theseItems.length - 1) && 'last-slide'}
+                  key={thisOffsetIndex}
                 >
-                  {theseItems[index].copy}
-                </SlideCopyWrapper>
 
-              </Slide>
-            );
-          })}
+                  <SlideCopyWrapper
+                    className="slide-copy-wrapper"
+                    mobileHeight={mobileHeight}
+                    tabletHeight={tabletHeight}
+                    desktopHeight={desktopHeight}
+                    nodeBackgroundColour={nodeBackgroundColour}
+                    nodeOutlineColour={nodeOutlineColour}
+                  >
+                    {theseItems[index].copy}
+                  </SlideCopyWrapper>
 
-          {/* Dummy slide for our desired non-mobile layout and functionality */}
-          {isMobile === false && (
-          <Slide index={theseItems.length + 1} key="bookend-last" />
-          )}
+                </Slide>
+              );
+            })}
 
-        </Slider>
-        <ButtonBack>Back</ButtonBack>
-        <ButtonNext>Next</ButtonNext>
-      </CarouselProvider>
-      )}
+            {/* Dummy slide for our desired non-mobile layout and functionality */}
+            {isMobile === false && (
+            <Slide index={theseItems.length + 1} key="bookend-last" />
+            )}
 
-    </CarouselWrapper>
+          </Slider>
+          <ButtonBack>Back</ButtonBack>
+          <ButtonNext>Next</ButtonNext>
+        </CarouselProvider>
+        )}
+
+      </CarouselWrapper>
+    </Container>
+
   );
 };
 
@@ -153,7 +164,10 @@ RichtextCarousel.propTypes = {
     desktopHeight: PropTypes.number,
     carouselBackgroundColour: PropTypes.string,
     nodeBackgroundColour: PropTypes.string,
-    nodeOutlineColour: PropTypes.string
+    nodeOutlineColour: PropTypes.string,
+    paddingTop: PropTypes.string,
+    paddingBottom: PropTypes.string,
+    rowBackgroundColour: PropTypes.string
   }).isRequired
 };
 

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.md
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.md
@@ -5,10 +5,23 @@ const { RichtextCarouselItems } = require('../../../styleguide/data/data');
 
     <div>
         <h2 style={{textAlign: 'center'}}>
-            Richtext Carousel #1
+            Richtext Carousel #1 (default padding)
         </h2>
         <RichtextCarousel
             data={RichtextCarouselItems}/>
+    </div>
+    
+```
+
+```js
+const { RichtextCarouselItemsWithPadding } = require('../../../styleguide/data/data');
+
+    <div>
+        <h2 style={{textAlign: 'center'}}>
+            Richtext Carousel #2 (custom padding)
+        </h2>
+        <RichtextCarousel
+            data={RichtextCarouselItemsWithPadding}/>
     </div>
     
 ```

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
@@ -242,7 +242,12 @@ const CarouselWrapper = styled.div`
   }
 `;
 
+const Container = styled.div`
+  background-color:   ${({ theme, rowBackgroundColour }) => theme.color(rowBackgroundColour)};
+  padding: ${({ paddingTop, paddingBottom }) => `${paddingTop} 0 ${paddingBottom}`};
+`;
+
 export {
   CarouselWrapper, SlideCopyWrapper,
-  HeadingCopyWrapper
+  HeadingCopyWrapper, Container
 };

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
@@ -3,19 +3,22 @@ import 'jest-styled-components';
 
 import renderWithTheme from '../../../../tests/hoc/shallowWithTheme';
 import RichtextCarousel from './RichtextCarousel';
-const { RichtextCarouselItems } = require('../../../styleguide/data/data');
+const {
+  RichtextCarouselItems,
+  RichtextCarouselItemsWithPadding,
+} = require('../../../styleguide/data/data');
 
-it('renders correctly', () => {
+it('renders default padding version correctly', () => {
   const tree = renderWithTheme(
     <RichtextCarousel data={RichtextCarouselItems} />
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
-    .c1 {
+    .c2 {
       text-align: center;
     }
 
-    .c0 {
+    .c1 {
       height: 100%;
       background: #FFFFFF;
       max-width: 760px;
@@ -25,14 +28,14 @@ it('renders correctly', () => {
       box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
     }
 
-    .c0 .carousel {
+    .c1 .carousel {
       position: relative;
       margin: 0 auto;
       padding-top: 2rem;
     }
 
-    .c0 .carousel button.carousel__back-button,
-    .c0 .carousel button.carousel__next-button {
+    .c1 .carousel button.carousel__back-button,
+    .c1 .carousel button.carousel__next-button {
       position: absolute;
       left: 0;
       top: 0;
@@ -45,8 +48,8 @@ it('renders correctly', () => {
       border: none;
     }
 
-    .c0 .carousel button.carousel__back-button:after,
-    .c0 .carousel button.carousel__next-button:after {
+    .c1 .carousel button.carousel__back-button:after,
+    .c1 .carousel button.carousel__next-button:after {
       content: "";
       position: absolute;
       top: 0;
@@ -58,29 +61,29 @@ it('renders correctly', () => {
       background: linear-gradient(90deg,#FFFFFF,#FFFFFF7a,#FFFFFF00);
     }
 
-    .c0 .carousel button.carousel__back-button:hover:after,
-    .c0 .carousel button.carousel__next-button:hover:after {
+    .c1 .carousel button.carousel__back-button:hover:after,
+    .c1 .carousel button.carousel__next-button:hover:after {
       opacity: 0.5;
     }
 
-    .c0 .carousel button.carousel__next-button {
+    .c1 .carousel button.carousel__next-button {
       left: auto;
       right: 0;
     }
 
-    .c0 .carousel button.carousel__next-button:before {
+    .c1 .carousel button.carousel__next-button:before {
       -webkit-transform: translate(0,-50%) rotate(-90deg);
       -ms-transform: translate(0,-50%) rotate(-90deg);
       transform: translate(0,-50%) rotate(-90deg);
     }
 
-    .c0 .carousel button.carousel__next-button:after {
+    .c1 .carousel button.carousel__next-button:after {
       left: auto;
       right: 0;
       background: linear-gradient(90deg,#FFFFFF00,#FFFFFF7a,#FFFFFF);
     }
 
-    .c0 .carousel .richtext-carousel {
+    .c1 .carousel .richtext-carousel {
       -webkit-transition: -webkit-transform 0.75s;
       -webkit-transition: -webkit-transform 0.75s;
       transition: -webkit-transform 0.75s;
@@ -92,15 +95,15 @@ it('renders correctly', () => {
       will-change: transform;
     }
 
-    .c0 .carousel .richtext-carousel .last-slide .slide-copy-wrapper:after {
+    .c1 .carousel .richtext-carousel .last-slide .slide-copy-wrapper:after {
       content: none;
     }
 
-    .c0 .carousel .richtext-carousel .carousel__slide {
+    .c1 .carousel .richtext-carousel .carousel__slide {
       padding-bottom: 300px !important;
     }
 
-    .c0 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide {
+    .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide {
       text-align: center;
       display: -webkit-inline-box;
       display: -webkit-inline-flex;
@@ -119,24 +122,29 @@ it('renders correctly', () => {
       flex-direction: column;
     }
 
+    .c0 {
+      background-color: #F4F3F5;
+      padding: 2rem 0 2rem;
+    }
+
     @media (min-width:740px) {
-      .c0 .carousel button.carousel__back-button,
-      .c0 .carousel button.carousel__next-button {
+      .c1 .carousel button.carousel__back-button,
+      .c1 .carousel button.carousel__next-button {
         width: 33.3% !important;
       }
 
-      .c0 .carousel button.carousel__back-button:after,
-      .c0 .carousel button.carousel__next-button:after {
+      .c1 .carousel button.carousel__back-button:after,
+      .c1 .carousel button.carousel__next-button:after {
         width: 100%;
       }
     }
 
     @media (min-width:740px) {
-      .c0 .carousel .richtext-carousel .carousel__slide {
+      .c1 .carousel .richtext-carousel .carousel__slide {
         padding-bottom: 350px !important;
       }
 
-      .c0 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide > div:first-child {
+      .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide > div:first-child {
         -webkit-transition: -webkit-transform 0.75s ease;
         -webkit-transition: transform 0.75s ease;
         transition: transform 0.75s ease;
@@ -148,7 +156,7 @@ it('renders correctly', () => {
         transform: scale(0.8);
       }
 
-      .c0 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide > div:first-child:after {
+      .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide > div:first-child:after {
         -webkit-transition: -webkit-transform 0.75s ease,width 0.75s ease,right 0.75s ease;
         -webkit-transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
         transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
@@ -159,7 +167,7 @@ it('renders correctly', () => {
         transform: scale(1);
       }
 
-      .c0 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
         width: 33%;
         right: calc(-33% - 3px);
         -webkit-transform: scale(1);
@@ -167,13 +175,13 @@ it('renders correctly', () => {
         transform: scale(1);
       }
 
-      .c0 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child {
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child {
         -webkit-transform: scale(1);
         -ms-transform: scale(1);
         transform: scale(1);
       }
 
-      .c0 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
         width: 33%;
         right: calc(-33% + 3px);
         -webkit-transform: scale(0.8);
@@ -181,13 +189,13 @@ it('renders correctly', () => {
         transform: scale(0.8);
       }
 
-      .c0 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child {
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child {
         -webkit-transform: scale(0.8);
         -ms-transform: scale(0.8);
         transform: scale(0.8);
       }
 
-      .c0 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child:after {
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child:after {
         width: 50%;
         right: calc(-50% - 6px);
         -webkit-transform: scale(1);
@@ -197,24 +205,496 @@ it('renders correctly', () => {
     }
 
     @media (min-width:1024px) {
-      .c0 .carousel .richtext-carousel .carousel__slide {
+      .c1 .carousel .richtext-carousel .carousel__slide {
         padding-bottom: 350px !important;
       }
 
-      .c0 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
         right: calc(-125% - 5px);
         width: 125%;
       }
     }
 
     <div
-      className="c0 CarouselWrapper"
-      id="nqIEHjiYE8Yd2A2a5cI3O"
+      className="c0"
     >
       <div
-        className="c1"
+        className="c1 CarouselWrapper"
+        id="nqIEHjiYE8Yd2A2a5cI3O"
       >
-        Some heading copy that will be nicely constructed in-situ
+        <div
+          className="c2"
+        >
+          Some heading copy that will be nicely constructed in-situ
+        </div>
+      </div>
+    </div>
+  `);
+});
+
+it('renders custom padding + background colour version correctly', () => {
+  const tree = renderWithTheme(
+    <RichtextCarousel data={RichtextCarouselItemsWithPadding} />
+  ).toJSON();
+
+  expect(tree).toMatchInlineSnapshot(`
+    .c3 {
+      background: #FFFFFF;
+      height: 300px;
+      width: 75%;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+      -webkit-box-pack: center;
+      -webkit-justify-content: center;
+      -ms-flex-pack: center;
+      justify-content: center;
+      padding: 25px;
+      border: 1px dashed #969598;
+      border-radius: 20px;
+      position: relative;
+      overflow: visible;
+      word-wrap: break-word;
+    }
+
+    .c3:after {
+      position: absolute;
+      content: '';
+      top: 50%;
+      width: 34%;
+      right: calc(-34% - 0px);
+      height: 2px;
+      border-bottom: 1px dashed #969598;
+    }
+
+    .c2 {
+      text-align: center;
+    }
+
+    .c1 {
+      height: 100%;
+      background: #FFFFFF;
+      max-width: 760px;
+      padding: 2.5rem 2rem 3.5rem;
+      margin: 0 auto;
+      border-radius: 20px;
+      box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
+    }
+
+    .c1 .carousel {
+      position: relative;
+      margin: 0 auto;
+      padding-top: 2rem;
+    }
+
+    .c1 .carousel button.carousel__back-button,
+    .c1 .carousel button.carousel__next-button {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 33% !important;
+      height: 100%;
+      padding: 0 !important;
+      box-shadow: none;
+      text-indent: -9999px;
+      background-color: transparent;
+      border: none;
+    }
+
+    .c1 .carousel button.carousel__back-button:after,
+    .c1 .carousel button.carousel__next-button:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 50%;
+      height: 100%;
+      -webkit-transition: opacity 0.2s linear;
+      transition: opacity 0.2s linear;
+      background: linear-gradient(90deg,#FFFFFF,#FFFFFF7a,#FFFFFF00);
+    }
+
+    .c1 .carousel button.carousel__back-button:hover:after,
+    .c1 .carousel button.carousel__next-button:hover:after {
+      opacity: 0.5;
+    }
+
+    .c1 .carousel button.carousel__next-button {
+      left: auto;
+      right: 0;
+    }
+
+    .c1 .carousel button.carousel__next-button:before {
+      -webkit-transform: translate(0,-50%) rotate(-90deg);
+      -ms-transform: translate(0,-50%) rotate(-90deg);
+      transform: translate(0,-50%) rotate(-90deg);
+    }
+
+    .c1 .carousel button.carousel__next-button:after {
+      left: auto;
+      right: 0;
+      background: linear-gradient(90deg,#FFFFFF00,#FFFFFF7a,#FFFFFF);
+    }
+
+    .c1 .carousel .richtext-carousel {
+      -webkit-transition: -webkit-transform 0.75s;
+      -webkit-transition: -webkit-transform 0.75s;
+      transition: -webkit-transform 0.75s;
+      -o-transition: transform 0.75s;
+      -webkit-transition: -webkit-transform 0.75s;
+      -webkit-transition: transform 0.75s;
+      transition: transform 0.75s;
+      -webkit-transform: 0.75s;
+      will-change: transform;
+    }
+
+    .c1 .carousel .richtext-carousel .last-slide .slide-copy-wrapper:after {
+      content: none;
+    }
+
+    .c1 .carousel .richtext-carousel .carousel__slide {
+      padding-bottom: 300px !important;
+    }
+
+    .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide {
+      text-align: center;
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-box-pack: start;
+      -webkit-justify-content: flex-start;
+      -ms-flex-pack: start;
+      justify-content: flex-start;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    .c0 {
+      background-color: #86E4E9;
+      padding: 4rem 0 4rem;
+    }
+
+    @media (min-width:740px) {
+      .c3 {
+        height: 350px;
+        width: 85%;
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c3 {
+        height: 350px;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c1 .carousel button.carousel__back-button,
+      .c1 .carousel button.carousel__next-button {
+        width: 33.3% !important;
+      }
+
+      .c1 .carousel button.carousel__back-button:after,
+      .c1 .carousel button.carousel__next-button:after {
+        width: 100%;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c1 .carousel .richtext-carousel .carousel__slide {
+        padding-bottom: 350px !important;
+      }
+
+      .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide > div:first-child {
+        -webkit-transition: -webkit-transform 0.75s ease;
+        -webkit-transition: transform 0.75s ease;
+        transition: transform 0.75s ease;
+        -webkit-transform-origin: center;
+        -ms-transform-origin: center;
+        transform-origin: center;
+        -webkit-transform: scale(0.8);
+        -ms-transform: scale(0.8);
+        transform: scale(0.8);
+      }
+
+      .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide > div:first-child:after {
+        -webkit-transition: -webkit-transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+        -webkit-transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+        transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+        width: 100%;
+        right: calc(-100% - 6px);
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        width: 33%;
+        right: calc(-33% - 3px);
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child {
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        width: 33%;
+        right: calc(-33% + 3px);
+        -webkit-transform: scale(0.8);
+        -ms-transform: scale(0.8);
+        transform: scale(0.8);
+      }
+
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child {
+        -webkit-transform: scale(0.8);
+        -ms-transform: scale(0.8);
+        transform: scale(0.8);
+      }
+
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child:after {
+        width: 50%;
+        right: calc(-50% - 6px);
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c1 .carousel .richtext-carousel .carousel__slide {
+        padding-bottom: 350px !important;
+      }
+
+      .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-125% - 5px);
+        width: 125%;
+      }
+    }
+
+    <div
+      className="c0"
+    >
+      <div
+        className="c1 CarouselWrapper"
+        id="nqIEHjiYE8Yd2A2a5cI31"
+      >
+        <div
+          className="c2"
+        >
+          Some heading copy that will be nicely constructed in-situ
+        </div>
+        <div
+          className="carousel"
+        >
+          <div
+            aria-label="slider"
+            aria-live="polite"
+            className="horizontalSlider___281Ls carousel__slider carousel__slider--horizontal"
+            onKeyDown={[Function]}
+            role="listbox"
+            style={Object {}}
+            tabIndex={0}
+          >
+            <div
+              className="carousel__slider-tray-wrapper carousel__slider-tray-wrap--horizontal"
+              style={Object {}}
+            >
+              <div
+                className="sliderTray___-vHFQ richtext-carousel carousel__slider-tray carousel__slider-tray--horizontal"
+                onClickCapture={[Function]}
+                onMouseDown={[Function]}
+                onTouchCancel={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "flexDirection": "row",
+                    "transform": "translateX(0%) translateX(0px)",
+                    "width": "200%",
+                  }
+                }
+              >
+                <div
+                  aria-label="slide"
+                  aria-selected={true}
+                  className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--visible"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  role="option"
+                  style={
+                    Object {
+                      "paddingBottom": "66.66666666666667%",
+                      "width": "16.666666666666668%",
+                    }
+                  }
+                  tabIndex={0}
+                >
+                  <div
+                    className="slideInner___2mfX9 carousel__inner-slide"
+                    style={Object {}}
+                  />
+                </div>
+                <div
+                  aria-label="slide"
+                  aria-selected={true}
+                  className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--visible"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  role="option"
+                  style={
+                    Object {
+                      "paddingBottom": "66.66666666666667%",
+                      "width": "16.666666666666668%",
+                    }
+                  }
+                  tabIndex={0}
+                >
+                  <div
+                    className="slideInner___2mfX9 carousel__inner-slide"
+                    style={Object {}}
+                  >
+                    <div
+                      className="c3 slide-copy-wrapper"
+                    >
+                      Some other longside but not really all that long copy, who knows, it could be this long or LESS.
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-label="slide"
+                  aria-selected={true}
+                  className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--visible"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  role="option"
+                  style={
+                    Object {
+                      "paddingBottom": "66.66666666666667%",
+                      "width": "16.666666666666668%",
+                    }
+                  }
+                  tabIndex={0}
+                >
+                  <div
+                    className="slideInner___2mfX9 carousel__inner-slide"
+                    style={Object {}}
+                  >
+                    <div
+                      className="c3 slide-copy-wrapper"
+                    >
+                      140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets.
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-label="slide"
+                  aria-selected={false}
+                  className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  role="option"
+                  style={
+                    Object {
+                      "paddingBottom": "66.66666666666667%",
+                      "width": "16.666666666666668%",
+                    }
+                  }
+                  tabIndex={-1}
+                >
+                  <div
+                    className="slideInner___2mfX9 carousel__inner-slide"
+                    style={Object {}}
+                  >
+                    <div
+                      className="c3 slide-copy-wrapper"
+                    >
+                      Some other longside but not really all that long copy, who knows, it could be this long or LESS
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-label="slide"
+                  aria-selected={false}
+                  className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden last-slide"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  role="option"
+                  style={
+                    Object {
+                      "paddingBottom": "66.66666666666667%",
+                      "width": "16.666666666666668%",
+                    }
+                  }
+                  tabIndex={-1}
+                >
+                  <div
+                    className="slideInner___2mfX9 carousel__inner-slide"
+                    style={Object {}}
+                  >
+                    <div
+                      className="c3 slide-copy-wrapper"
+                    >
+                      140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets. ABIGLONGLINETOFORCEONTOANEWONE
+                    </div>
+                  </div>
+                </div>
+                <div
+                  aria-label="slide"
+                  aria-selected={false}
+                  className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  role="option"
+                  style={
+                    Object {
+                      "paddingBottom": "66.66666666666667%",
+                      "width": "16.666666666666668%",
+                    }
+                  }
+                  tabIndex={-1}
+                >
+                  <div
+                    className="slideInner___2mfX9 carousel__inner-slide"
+                    style={Object {}}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <button
+            aria-label="previous"
+            className="buttonBack___1mlaL carousel__back-button"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            Back
+          </button>
+          <button
+            aria-label="next"
+            className="buttonNext___2mOCa carousel__next-button"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            Next
+          </button>
+        </div>
       </div>
     </div>
   `);

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
@@ -17,12 +17,12 @@ import { breakpointValues } from '../../../theme/shared/allBreakpoints';
 const WYMDCarousel = ({ data }) => {
   const {
     autoPlay,
+    contentful_id: thisID,
     desktopHeight,
     headerCopy,
     mobileHeight,
     peopleHelpedText,
     tabletHeight,
-    contentful_id: thisID,
     paddingTop = '2rem',
     paddingBottom = '2rem'
   } = data;

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
@@ -23,6 +23,7 @@ const WYMDCarousel = ({ data }) => {
     mobileHeight,
     peopleHelpedText,
     tabletHeight,
+    backgroundColour = 'grey_light',
     paddingTop = '2rem',
     paddingBottom = '2rem'
   } = data;
@@ -71,6 +72,7 @@ const WYMDCarousel = ({ data }) => {
     <Container
       paddingTop={paddingTop}
       paddingBottom={paddingBottom}
+      backgroundColour={backgroundColour}
     >
       <CarouselWrapper
         className="CarouselWrapper"
@@ -236,7 +238,8 @@ WYMDCarousel.propTypes = {
     tabletHeight: PropTypes.number,
     desktopHeight: PropTypes.number,
     paddingTop: PropTypes.string,
-    paddingBottom: PropTypes.string
+    paddingBottom: PropTypes.string,
+    backgroundColour: PropTypes.string
   }).isRequired
 };
 

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
@@ -8,12 +8,25 @@ import {
 import formatItems from './_utils';
 import 'pure-react-carousel/dist/react-carousel.es.css';
 import {
-  CarouselWrapper, ImageWrapper, AmountWrapper, CopyWrapper, Heading, PeopleHelpedText, Including
+  CarouselWrapper, ImageWrapper, AmountWrapper, CopyWrapper,
+  Heading, PeopleHelpedText, Including, Container
 } from './WYMDCarousel.style';
 import Text from '../../Atoms/Text/Text';
 import { breakpointValues } from '../../../theme/shared/allBreakpoints';
 
-const WYMDCarousel = ({ data, data: { autoPlay, contentful_id: thisID } }) => {
+const WYMDCarousel = ({ data }) => {
+  const {
+    autoPlay,
+    desktopHeight,
+    headerCopy,
+    mobileHeight,
+    peopleHelpedText,
+    tabletHeight,
+    contentful_id: thisID,
+    paddingTop = '0rem',
+    paddingBottom = '0rem'
+  } = data;
+
   // Defaults to mobile config:
   const [isMobile, setIsMobile] = useState(true);
   const [visibleSlides, setVisibleSlides] = useState(1);
@@ -55,90 +68,96 @@ const WYMDCarousel = ({ data, data: { autoPlay, contentful_id: thisID } }) => {
   }
 
   return (
-    <CarouselWrapper
-      className="CarouselWrapper"
-      id={thisID}
-      mobileHeight={data.mobileHeight}
-      tabletHeight={data.tabletHeight}
-      desktopHeight={data.desktopHeight}
+    <Container
+      paddingTop={paddingTop}
+      paddingBottom={paddingBottom}
     >
-
-      <Heading tag="p" weight="bold">
-        { data.headerCopy}
-      </Heading>
-
-      <PeopleHelpedText tag="h1" family="Anton" weight="normal" color="red">
-        { data.peopleHelpedText}
-      </PeopleHelpedText>
-
-      <Including tag="p">
-        including...
-      </Including>
-
-      {theseItems && (
-      <CarouselProvider
-        naturalSlideWidth={50}
-        naturalSlideHeight={200}
-        totalSlides={totalSlides}
-        isPlaying={autoPlay}
-        interval={5000}
-        visibleSlides={visibleSlides}
-        infinite
+      <CarouselWrapper
+        className="CarouselWrapper"
+        id={thisID}
+        mobileHeight={mobileHeight}
+        tabletHeight={tabletHeight}
+        desktopHeight={desktopHeight}
       >
-        <Slider classNameAnimation="wymd-carousel">
 
-          {/* Dummy slide for our desired non-mobile layout and functionality */}
-          {isMobile === false && (
-          <Slide index={0} key={0} />
-          )}
+        <Heading tag="p" weight="bold">
+          { headerCopy}
+        </Heading>
 
-          {Object.keys(theseItems).map((key, index) => {
+        <PeopleHelpedText tag="h1" family="Anton" weight="normal" color="red">
+          { peopleHelpedText}
+        </PeopleHelpedText>
+
+        <Including tag="p">
+          including...
+        </Including>
+
+        {theseItems && (
+        <CarouselProvider
+          naturalSlideWidth={50}
+          naturalSlideHeight={200}
+          totalSlides={totalSlides}
+          isPlaying={autoPlay}
+          interval={5000}
+          visibleSlides={visibleSlides}
+          infinite
+        >
+          <Slider classNameAnimation="wymd-carousel">
+
+            {/* Dummy slide for our desired non-mobile layout and functionality */}
+            {isMobile === false && (
+            <Slide index={0} key={0} />
+            )}
+
+            {Object.keys(theseItems).map((key, index) => {
             // Reflect that initial dummy/bookend slide shown on non-mobile/tablet views:
-            const thisOffsetIndex = index + (isMobile ? 0 : 1);
+              const thisOffsetIndex = index + (isMobile ? 0 : 1);
 
-            return (
+              return (
               // Calculate the index offset accordingly to reflect the number of slides,
               // but use the REAL index when determining if its the last REAL slide
-              <Slide
-                index={thisOffsetIndex}
-                className={index === (theseItems.length - 1) && 'last-slide'}
-                key={thisOffsetIndex}
-              >
+                <Slide
+                  index={thisOffsetIndex}
+                  className={index === (theseItems.length - 1) && 'last-slide'}
+                  key={thisOffsetIndex}
+                >
 
-                <ImageWrapper className="image-wrapper">
-                  <img src={theseItems[key].image.file.url} alt={theseItems[key].copy} />
-                </ImageWrapper>
+                  <ImageWrapper className="image-wrapper">
+                    <img src={theseItems[key].image.file.url} alt={theseItems[key].copy} />
+                  </ImageWrapper>
 
-                <div className="all-text-wrapper">
-                  <AmountWrapper>
-                    <Text tag="h1" family="Anton" weight="normal" size="s">
-                      {theseItems[key].amount}
-                    </Text>
-                  </AmountWrapper>
+                  <div className="all-text-wrapper">
+                    <AmountWrapper>
+                      <Text tag="h1" family="Anton" weight="normal" size="s">
+                        {theseItems[key].amount}
+                      </Text>
+                    </AmountWrapper>
 
-                  <CopyWrapper>
-                    <Text tag="p" size="s">
-                      {theseItems[key].copy}
-                    </Text>
-                  </CopyWrapper>
-                </div>
+                    <CopyWrapper>
+                      <Text tag="p" size="s">
+                        {theseItems[key].copy}
+                      </Text>
+                    </CopyWrapper>
+                  </div>
 
-              </Slide>
-            );
-          })}
+                </Slide>
+              );
+            })}
 
-          {/* Dummy slide for our desired non-mobile layout and functionality */}
-          {isMobile === false && (
-          <Slide index={theseItems.length + 1} key="bookend-last" />
-          )}
+            {/* Dummy slide for our desired non-mobile layout and functionality */}
+            {isMobile === false && (
+            <Slide index={theseItems.length + 1} key="bookend-last" />
+            )}
 
-        </Slider>
-        <ButtonBack>Back</ButtonBack>
-        <ButtonNext>Next</ButtonNext>
-      </CarouselProvider>
-      )}
+          </Slider>
+          <ButtonBack>Back</ButtonBack>
+          <ButtonNext>Next</ButtonNext>
+        </CarouselProvider>
+        )}
 
-    </CarouselWrapper>
+      </CarouselWrapper>
+    </Container>
+
   );
 };
 
@@ -215,7 +234,9 @@ WYMDCarousel.propTypes = {
     contentful_id: PropTypes.string.isRequired,
     mobileHeight: PropTypes.number,
     tabletHeight: PropTypes.number,
-    desktopHeight: PropTypes.number
+    desktopHeight: PropTypes.number,
+    paddingTop: PropTypes.string,
+    paddingBottom: PropTypes.string
   }).isRequired
 };
 

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
@@ -130,13 +130,13 @@ const WYMDCarousel = ({ data }) => {
 
                   <div className="all-text-wrapper">
                     <AmountWrapper>
-                      <Text tag="h1" family="Anton" weight="normal" size="s">
+                      <Text tag="h1" family="Anton">
                         {theseItems[key].amount}
                       </Text>
                     </AmountWrapper>
 
                     <CopyWrapper>
-                      <Text tag="p" size="s">
+                      <Text tag="p">
                         {theseItems[key].copy}
                       </Text>
                     </CopyWrapper>

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
@@ -23,8 +23,8 @@ const WYMDCarousel = ({ data }) => {
     peopleHelpedText,
     tabletHeight,
     contentful_id: thisID,
-    paddingTop = '0rem',
-    paddingBottom = '0rem'
+    paddingTop = '2rem',
+    paddingBottom = '2rem'
   } = data;
 
   // Defaults to mobile config:

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.md
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.md
@@ -6,11 +6,22 @@ import Text from '../../Atoms/Text/Text';
 
     <div>
         <h2 style={{textAlign: 'center'}}>
-            All fields supplied, autoplay on:
+            All fields supplied, autoplay on, default padding:
         </h2>
         <WYMDCarousel data={carouselItemsComplete}/>
     </div>
-    
+```
+
+```js
+const { carouselItemsCompleteWithPadding } = require('../../../styleguide/data/data');
+import Text from '../../Atoms/Text/Text';
+
+    <div>
+        <h2 style={{textAlign: 'center'}}>
+            All fields supplied, autoplay on, custom padding:
+        </h2>
+        <WYMDCarousel data={carouselItemsCompleteWithPadding}/>
+    </div>
 ```
 
 ```js
@@ -23,7 +34,6 @@ import Text from '../../Atoms/Text/Text';
         </h2>
         <WYMDCarousel data={carouselItemsIncomplete}/>
     </div>
-    
 ```
 
 ```js
@@ -36,5 +46,4 @@ import Text from '../../Atoms/Text/Text';
         </h2>
         <WYMDCarousel data={carouselItemsMinimal}/>
     </div>
-    
 ```

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.style.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.style.js
@@ -347,6 +347,7 @@ const CarouselWrapper = styled.div`
 `;
 
 const Container = styled.div`
+  background-color:   ${({ theme, backgroundColour }) => theme.color(backgroundColour)};
   padding: ${({ paddingTop, paddingBottom }) => `${paddingTop} 0 ${paddingBottom};`}
 `;
 

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.style.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.style.js
@@ -126,7 +126,7 @@ const CarouselWrapper = styled.div`
   margin: 0 auto;
 
   border-radius: 20px;
- ${defaultBoxShadow()}
+  ${defaultBoxShadow()}
 
   .carousel {
     position: relative;
@@ -334,7 +334,6 @@ const CarouselWrapper = styled.div`
         }
         // END OF DESKTOP
 
-
         .carousel__inner-slide {
           text-align: center;
           display: inline-flex;
@@ -347,6 +346,11 @@ const CarouselWrapper = styled.div`
   }
 `;
 
+const Container = styled.div`
+  padding: ${({ paddingTop, paddingBottom }) => `${paddingTop} 0 ${paddingBottom};`}
+`;
+
 export {
-  CarouselWrapper, ImageWrapper, AmountWrapper, CopyWrapper, Heading, PeopleHelpedText, Including
+  CarouselWrapper, ImageWrapper, AmountWrapper, CopyWrapper,
+  Heading, PeopleHelpedText, Including, Container
 };

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.test.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.test.js
@@ -3,11 +3,359 @@ import "jest-styled-components";
 
 import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
 import WYMDCarousel from "./WYMDCarousel";
-const { carouselItemsComplete } = require("../../../styleguide/data/data");
+const { carouselItemsComplete, carouselItemsCompleteWithPadding } = require("../../../styleguide/data/data");
 
-it("renders correctly", () => {
+it("renders the default padding version correctly", () => {
   const tree = renderWithTheme(
     <WYMDCarousel data={carouselItemsComplete} />
+  ).toJSON();
+
+  expect(tree).toMatchSnapshot(`
+    .c1 {
+      font-size: 1rem;
+      line-height: 1rem;
+      text-transform: inherit;
+      font-weight: bold;
+      line-height: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+    }
+
+    .c3 {
+      color: #E52630;
+      font-size: 1rem;
+      line-height: 1rem;
+      text-transform: uppercase;
+      font-weight: normal;
+      font-family: 'Anton',Impact,sans-serif;
+      -webkit-letter-spacing: 0.03rem;
+      -moz-letter-spacing: 0.03rem;
+      -ms-letter-spacing: 0.03rem;
+      letter-spacing: 0.03rem;
+    }
+
+    .c5 {
+      font-size: 1rem;
+      line-height: 1rem;
+      text-transform: inherit;
+      line-height: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+    }
+
+    .c2 {
+      width: 75%;
+      margin: 0 auto;
+    }
+
+    .c2:first-child {
+      margin-bottom: 2rem;
+      text-align: center;
+      font-size: 16px;
+      line-height: 19.5px;
+    }
+
+    .c4 {
+      margin-bottom: 2rem;
+      text-align: center;
+      font-size: 34px;
+      line-height: 37px;
+    }
+
+    .c6 {
+      margin-bottom: 0;
+      text-align: center;
+      font-size: 12px;
+      line-height: 14.63px;
+    }
+
+    .c0 {
+      height: 100%;
+      background-color: #FFFFFF;
+      max-width: 760px;
+      padding: 2rem;
+      margin: 0 auto;
+      border-radius: 20px;
+      box-shadow: 0px 0px 20px rgba(0,0,0,0.15);
+    }
+
+    .c0 .carousel {
+      position: relative;
+      margin: 0 auto;
+      padding-top: 2rem;
+    }
+
+    .c0 .carousel button.carousel__back-button,
+    .c0 .carousel button.carousel__next-button {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 33% !important;
+      height: 100%;
+      padding: 0 !important;
+      box-shadow: none;
+      text-indent: -9999px;
+      background-color: transparent;
+      border: none;
+    }
+
+    .c0 .carousel button.carousel__back-button:after,
+    .c0 .carousel button.carousel__next-button:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 50%;
+      height: 100%;
+      -webkit-transition: opacity 0.2s linear;
+      transition: opacity 0.2s linear;
+      background: linear-gradient(90deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
+    }
+
+    .c0 .carousel button.carousel__back-button:hover:after,
+    .c0 .carousel button.carousel__next-button:hover:after {
+      opacity: 0.5;
+    }
+
+    .c0 .carousel button.carousel__next-button {
+      left: auto;
+      right: 0;
+    }
+
+    .c0 .carousel button.carousel__next-button:before {
+      -webkit-transform: translate(0,-50%) rotate(-90deg);
+      -ms-transform: translate(0,-50%) rotate(-90deg);
+      transform: translate(0,-50%) rotate(-90deg);
+    }
+
+    .c0 .carousel button.carousel__next-button:after {
+      left: auto;
+      right: 0;
+      background: linear-gradient(270deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
+    }
+
+    .c0 .carousel .wymd-carousel {
+      -webkit-transition: -webkit-transform 0.75s;
+      -webkit-transition: -webkit-transform 0.75s;
+      transition: -webkit-transform 0.75s;
+      -o-transition: transform 0.75s;
+      -webkit-transition: -webkit-transform 0.75s;
+      -webkit-transition: transform 0.75s;
+      transition: transform 0.75s;
+      -webkit-transform: 0.75s;
+      will-change: transform;
+    }
+
+    .c0 .carousel .wymd-carousel .last-slide .image-wrapper:after {
+      content: none;
+    }
+
+    .c0 .carousel .wymd-carousel .carousel__slide {
+      padding-bottom: 425px !important;
+    }
+
+    .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide {
+      text-align: center;
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-box-pack: start;
+      -webkit-justify-content: flex-start;
+      -ms-flex-pack: start;
+      justify-content: flex-start;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (min-width:1024px) {
+      .c2:first-child {
+        font-size: 20px;
+        line-height: 24.38px;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c4 {
+        font-size: 60px;
+        line-height: 60px;
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c4 {
+        font-size: 64px;
+        line-height: 68px;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c6 {
+        font-size: 17px;
+        line-height: 19px;
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c0 .carousel {
+        padding-top: 2rem;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c0 .carousel button.carousel__back-button,
+      .c0 .carousel button.carousel__next-button {
+        width: 33.3% !important;
+      }
+
+      .c0 .carousel button.carousel__back-button:after,
+      .c0 .carousel button.carousel__next-button:after {
+        width: 100%;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c0 .carousel .wymd-carousel .carousel__slide {
+        padding-bottom: 450px !important;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child {
+        -webkit-transition: -webkit-transform 0.75s ease;
+        -webkit-transition: transform 0.75s ease;
+        transition: transform 0.75s ease;
+        -webkit-transform: scale(0.5);
+        -ms-transform: scale(0.5);
+        transform: scale(0.5);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child:after {
+        -webkit-transition: -webkit-transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+        -webkit-transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+        transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+        right: calc(-300% - 6px);
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+        width: 300%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide .all-text-wrapper {
+        -webkit-transition: -webkit-transform 0.75s ease;
+        -webkit-transition: transform 0.75s ease;
+        transition: transform 0.75s ease;
+        -webkit-transform-origin: top;
+        -ms-transform-origin: top;
+        transform-origin: top;
+        -webkit-transform: translateY(calc(-45px + 5%)) scale(0.5);
+        -ms-transform: translateY(calc(-45px + 5%)) scale(0.5);
+        transform: translateY(calc(-45px + 5%)) scale(0.5);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-300% - 6px);
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+        width: 300%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child {
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-222% - 6px);
+        -webkit-transform: scale(0.5);
+        -ms-transform: scale(0.5);
+        transform: scale(0.5);
+        width: 300%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
+        -webkit-transform: translateY(0) scale(1);
+        -ms-transform: translateY(0) scale(1);
+        transform: translateY(0) scale(1);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child {
+        -webkit-transform: scale(0.5);
+        -ms-transform: scale(0.5);
+        transform: scale(0.5);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child:after {
+        right: calc(-300% - 6px);
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+        width: 300%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
+        -webkit-transform: translateY(calc(-45px + 5%)) scale(0.5);
+        -ms-transform: translateY(calc(-45px + 5%)) scale(0.5);
+        transform: translateY(calc(-45px + 5%)) scale(0.5);
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c0 .carousel .wymd-carousel .carousel__slide {
+        padding-bottom: 475px !important;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-250% - 6px);
+        width: 250%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-187% - 6px);
+        width: 250%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-250% - 6px);
+        width: 250%;
+      }
+    }
+
+    <div
+      className="c0 CarouselWrapper"
+      id="7zdR84QkZwrTh9NWx2H926"
+    >
+      <p
+        className="c1 c2"
+        color="inherit"
+        size="s"
+      >
+        Over the past two years, we’ve supported
+      </p>
+      <h1
+        className="c3 c4"
+        color="red"
+        size="s"
+      >
+        11.7 million people
+      </h1>
+      <p
+        className="c5 c6"
+        color="inherit"
+        size="s"
+      >
+        including...
+      </p>
+    </div>
+  `);
+});
+
+it("renders the customised padding version correctly", () => {
+  const tree = renderWithTheme(
+    <WYMDCarousel data={carouselItemsCompleteWithPadding} />
   ).toJSON();
 
   expect(tree).toMatchSnapshot(`

--- a/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
+++ b/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly: 
+exports[`renders the customised padding version correctly: 
     .c1 {
       font-size: 1rem;
       line-height: 1rem;
@@ -341,7 +341,7 @@ exports[`renders correctly:
       </p>
     </div>
    1`] = `
-.c1 {
+.c2 {
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
   font-weight: 400;
   text-transform: inherit;
@@ -353,16 +353,16 @@ exports[`renders correctly:
   line-height: 1.25rem;
 }
 
-.c1 {
+.c2 {
   font-weight: bold;
 }
 
-.c1 span {
+.c2 span {
   font-size: inherit;
   line-height: inherit;
 }
 
-.c3 {
+.c4 {
   font-family: 'Anton',Impact,sans-serif;
   font-weight: 400;
   text-transform: uppercase;
@@ -374,18 +374,18 @@ exports[`renders correctly:
   line-height: 2rem;
 }
 
-.c3 {
+.c4 {
   font-family: 'Anton',Impact,sans-serif;
   font-weight: normal;
   color: #E52630;
 }
 
-.c3 span {
+.c4 span {
   font-size: inherit;
   line-height: inherit;
 }
 
-.c5 {
+.c6 {
   font-family: 'Montserrat',Helvetica,Arial,sans-serif;
   font-weight: 400;
   text-transform: inherit;
@@ -397,38 +397,130 @@ exports[`renders correctly:
   line-height: 1.25rem;
 }
 
-.c5 span {
+.c6 span {
   font-size: inherit;
   line-height: inherit;
 }
 
-.c2 {
+.c10 {
+  font-family: 'Anton',Impact,sans-serif;
+  font-weight: 400;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  font-size: 2rem;
+  line-height: 2rem;
+}
+
+.c10 {
+  font-size: 1rem;
+  line-height: normal;
+  font-family: 'Anton',Impact,sans-serif;
+  font-weight: normal;
+}
+
+.c10 span {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.c12 {
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  font-size: 1rem;
+  line-height: 1.25rem;
+}
+
+.c12 {
+  font-size: 1rem;
+  line-height: normal;
+}
+
+.c12 span {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.c8 {
+  width: 45%;
+  display: block;
+  padding: 9%;
+  border: 2px dashed #89888b;
+  border-radius: 50%;
+  position: relative;
+  overflow: visible;
+}
+
+.c8 img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.c8:after {
+  position: absolute;
+  content: '';
+  top: 50%;
+  width: 125%;
+  right: calc(-125% - 2px);
+  height: 2px;
+  border-bottom: 2px dashed #89888b;
+}
+
+.c9 {
+  padding: 1.5rem 0 0.75rem;
+}
+
+.c9 h1 {
+  font-size: 34px;
+  line-height: 37px;
+}
+
+.c11 {
+  padding: 0;
   width: 75%;
   margin: 0 auto;
 }
 
-.c2:first-child {
+.c11 p {
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.c3 {
+  width: 75%;
+  margin: 0 auto;
+}
+
+.c3:first-child {
   margin-bottom: 2rem;
   text-align: center;
   font-size: 16px;
   line-height: 19.5px;
 }
 
-.c4 {
+.c5 {
   margin-bottom: 2rem;
   text-align: center;
   font-size: 34px;
   line-height: 37px;
 }
 
-.c6 {
+.c7 {
   margin-bottom: 0;
   text-align: center;
   font-size: 12px;
   line-height: 14.63px;
 }
 
-.c0 {
+.c1 {
   height: 100%;
   background-color: #FFFFFF;
   max-width: 760px;
@@ -438,14 +530,14 @@ exports[`renders correctly:
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
 }
 
-.c0 .carousel {
+.c1 .carousel {
   position: relative;
   margin: 0 auto;
   padding-top: 2rem;
 }
 
-.c0 .carousel button.carousel__back-button,
-.c0 .carousel button.carousel__next-button {
+.c1 .carousel button.carousel__back-button,
+.c1 .carousel button.carousel__next-button {
   position: absolute;
   left: 0;
   top: 0;
@@ -458,8 +550,8 @@ exports[`renders correctly:
   border: none;
 }
 
-.c0 .carousel button.carousel__back-button:after,
-.c0 .carousel button.carousel__next-button:after {
+.c1 .carousel button.carousel__back-button:after,
+.c1 .carousel button.carousel__next-button:after {
   content: "";
   position: absolute;
   top: 0;
@@ -471,29 +563,29 @@ exports[`renders correctly:
   background: linear-gradient(90deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
 }
 
-.c0 .carousel button.carousel__back-button:hover:after,
-.c0 .carousel button.carousel__next-button:hover:after {
+.c1 .carousel button.carousel__back-button:hover:after,
+.c1 .carousel button.carousel__next-button:hover:after {
   opacity: 0.5;
 }
 
-.c0 .carousel button.carousel__next-button {
+.c1 .carousel button.carousel__next-button {
   left: auto;
   right: 0;
 }
 
-.c0 .carousel button.carousel__next-button:before {
+.c1 .carousel button.carousel__next-button:before {
   -webkit-transform: translate(0,-50%) rotate(-90deg);
   -ms-transform: translate(0,-50%) rotate(-90deg);
   transform: translate(0,-50%) rotate(-90deg);
 }
 
-.c0 .carousel button.carousel__next-button:after {
+.c1 .carousel button.carousel__next-button:after {
   left: auto;
   right: 0;
   background: linear-gradient(270deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
 }
 
-.c0 .carousel .wymd-carousel {
+.c1 .carousel .wymd-carousel {
   -webkit-transition: -webkit-transform 0.75s;
   -webkit-transition: -webkit-transform 0.75s;
   transition: -webkit-transform 0.75s;
@@ -505,15 +597,15 @@ exports[`renders correctly:
   will-change: transform;
 }
 
-.c0 .carousel .wymd-carousel .last-slide .image-wrapper:after {
+.c1 .carousel .wymd-carousel .last-slide .image-wrapper:after {
   content: none;
 }
 
-.c0 .carousel .wymd-carousel .carousel__slide {
+.c1 .carousel .wymd-carousel .carousel__slide {
   padding-bottom: 425px !important;
 }
 
-.c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide {
+.c1 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide {
   text-align: center;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -532,100 +624,151 @@ exports[`renders correctly:
   flex-direction: column;
 }
 
+.c0 {
+  padding: 4rem 0 4rem;
+}
+
 @media (min-width:740px) {
-  .c1 {
+  .c2 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:1024px) {
-  .c1 {
+  .c2 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:740px) {
-  .c3 {
+  .c4 {
     font-size: 2.5rem;
     line-height: 2.5rem;
   }
 }
 
 @media (min-width:1024px) {
-  .c3 {
+  .c4 {
     font-size: 3rem;
     line-height: 3rem;
   }
 }
 
 @media (min-width:740px) {
-  .c5 {
+  .c6 {
     font-size: 1rem;
     line-height: 1.25rem;
   }
 }
 
 @media (min-width:1024px) {
-  .c5 {
+  .c6 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c10 {
+    font-size: 2.5rem;
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c10 {
+    font-size: 3rem;
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c12 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c12 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
 }
 
 @media (min-width:1024px) {
-  .c2:first-child {
+  .c8 {
+    width: 50%;
+    padding: 9%;
+  }
+
+  .c8:after {
+    width: 100%;
+    right: calc(-100% - 8px);
+  }
+}
+
+@media (min-width:740px) {
+  .c9 h1 {
+    font-size: 40px;
+    line-height: 40px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3:first-child {
     font-size: 20px;
     line-height: 24.38px;
   }
 }
 
 @media (min-width:740px) {
-  .c4 {
+  .c5 {
     font-size: 60px;
     line-height: 60px;
   }
 }
 
 @media (min-width:1024px) {
-  .c4 {
+  .c5 {
     font-size: 64px;
     line-height: 68px;
   }
 }
 
 @media (min-width:740px) {
-  .c6 {
+  .c7 {
     font-size: 17px;
     line-height: 19px;
   }
 }
 
 @media (min-width:1024px) {
-  .c0 .carousel {
+  .c1 .carousel {
     padding-top: 2rem;
   }
 }
 
 @media (min-width:740px) {
-  .c0 .carousel button.carousel__back-button,
-  .c0 .carousel button.carousel__next-button {
+  .c1 .carousel button.carousel__back-button,
+  .c1 .carousel button.carousel__next-button {
     width: 33.3% !important;
   }
 
-  .c0 .carousel button.carousel__back-button:after,
-  .c0 .carousel button.carousel__next-button:after {
+  .c1 .carousel button.carousel__back-button:after,
+  .c1 .carousel button.carousel__next-button:after {
     width: 100%;
   }
 }
 
 @media (min-width:740px) {
-  .c0 .carousel .wymd-carousel .carousel__slide {
+  .c1 .carousel .wymd-carousel .carousel__slide {
     padding-bottom: 450px !important;
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child {
+  .c1 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child {
     -webkit-transition: -webkit-transform 0.75s ease;
     -webkit-transition: transform 0.75s ease;
     transition: transform 0.75s ease;
@@ -634,7 +777,7 @@ exports[`renders correctly:
     transform: scale(0.5);
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child:after {
+  .c1 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child:after {
     -webkit-transition: -webkit-transform 0.75s ease,width 0.75s ease,right 0.75s ease;
     -webkit-transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
     transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
@@ -645,7 +788,7 @@ exports[`renders correctly:
     width: 300%;
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide .all-text-wrapper {
+  .c1 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide .all-text-wrapper {
     -webkit-transition: -webkit-transform 0.75s ease;
     -webkit-transition: transform 0.75s ease;
     transition: transform 0.75s ease;
@@ -657,7 +800,7 @@ exports[`renders correctly:
     transform: translateY(calc(-45px + 5%)) scale(0.5);
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
     right: calc(-300% - 6px);
     -webkit-transform: scale(1);
     -ms-transform: scale(1);
@@ -665,13 +808,13 @@ exports[`renders correctly:
     width: 300%;
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child {
     -webkit-transform: scale(1);
     -ms-transform: scale(1);
     transform: scale(1);
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
     right: calc(-222% - 6px);
     -webkit-transform: scale(0.5);
     -ms-transform: scale(0.5);
@@ -679,19 +822,19 @@ exports[`renders correctly:
     width: 300%;
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
     -webkit-transform: translateY(0) scale(1);
     -ms-transform: translateY(0) scale(1);
     transform: translateY(0) scale(1);
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child {
     -webkit-transform: scale(0.5);
     -ms-transform: scale(0.5);
     transform: scale(0.5);
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child:after {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child:after {
     right: calc(-300% - 6px);
     -webkit-transform: scale(1);
     -ms-transform: scale(1);
@@ -699,7 +842,7 @@ exports[`renders correctly:
     width: 300%;
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
     -webkit-transform: translateY(calc(-45px + 5%)) scale(0.5);
     -ms-transform: translateY(calc(-45px + 5%)) scale(0.5);
     transform: translateY(calc(-45px + 5%)) scale(0.5);
@@ -707,44 +850,1358 @@ exports[`renders correctly:
 }
 
 @media (min-width:1024px) {
-  .c0 .carousel .wymd-carousel .carousel__slide {
+  .c1 .carousel .wymd-carousel .carousel__slide {
     padding-bottom: 475px !important;
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
     right: calc(-250% - 6px);
     width: 250%;
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
     right: calc(-187% - 6px);
     width: 250%;
   }
 
-  .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
     right: calc(-250% - 6px);
     width: 250%;
   }
 }
 
 <div
-  className="c0 CarouselWrapper"
-  id="7zdR84QkZwrTh9NWx2H926"
+  className="c0"
 >
-  <p
-    className="c1 c2"
+  <div
+    className="c1 CarouselWrapper"
+    id="7zdR84QkZwrTh9NWx2H926"
   >
-    Over the past two years, we’ve supported
-  </p>
-  <h1
-    className="c3 c4"
+    <p
+      className="c2 c3"
+    >
+      Over the past two years, we’ve supported
+    </p>
+    <h1
+      className="c4 c5"
+    >
+      11.7 million people
+    </h1>
+    <p
+      className="c6 c7"
+    >
+      including...
+    </p>
+    <div
+      className="carousel"
+    >
+      <div
+        aria-label="slider"
+        aria-live="polite"
+        className="horizontalSlider___281Ls carousel__slider carousel__slider--horizontal"
+        onKeyDown={[Function]}
+        role="listbox"
+        style={Object {}}
+        tabIndex={0}
+      >
+        <div
+          className="carousel__slider-tray-wrapper carousel__slider-tray-wrap--horizontal"
+          style={Object {}}
+        >
+          <div
+            className="sliderTray___-vHFQ wymd-carousel carousel__slider-tray carousel__slider-tray--horizontal"
+            onClickCapture={[Function]}
+            onMouseDown={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            style={
+              Object {
+                "flexDirection": "row",
+                "transform": "translateX(0%) translateX(0px)",
+                "width": "366.6666666666667%",
+              }
+            }
+          >
+            <div
+              aria-label="slide"
+              aria-selected={true}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--visible"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={0}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              />
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={true}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--visible"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={0}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              >
+                <div
+                  className="c8 image-wrapper"
+                >
+                  <img
+                    alt="children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education."
+                    src="//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png"
+                  />
+                </div>
+                <div
+                  className="all-text-wrapper"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <h1
+                      className="c10"
+                    >
+                      1,000
+                    </h1>
+                  </div>
+                  <div
+                    className="c11"
+                  >
+                    <p
+                      className="c12"
+                    >
+                      children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={true}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--visible"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={0}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              >
+                <div
+                  className="c8 image-wrapper"
+                >
+                  <img
+                    alt="children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education."
+                    src="//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png"
+                  />
+                </div>
+                <div
+                  className="all-text-wrapper"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <h1
+                      className="c10"
+                    >
+                      750,000
+                    </h1>
+                  </div>
+                  <div
+                    className="c11"
+                  >
+                    <p
+                      className="c12"
+                    >
+                      children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={false}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              >
+                <div
+                  className="c8 image-wrapper"
+                >
+                  <img
+                    alt="children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education."
+                    src="//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png"
+                  />
+                </div>
+                <div
+                  className="all-text-wrapper"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <h1
+                      className="c10"
+                    >
+                      3,000
+                    </h1>
+                  </div>
+                  <div
+                    className="c11"
+                  >
+                    <p
+                      className="c12"
+                    >
+                      children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={false}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              >
+                <div
+                  className="c8 image-wrapper"
+                >
+                  <img
+                    alt="children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education."
+                    src="//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png"
+                  />
+                </div>
+                <div
+                  className="all-text-wrapper"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <h1
+                      className="c10"
+                    >
+                      4,000
+                    </h1>
+                  </div>
+                  <div
+                    className="c11"
+                  >
+                    <p
+                      className="c12"
+                    >
+                      children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={false}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              >
+                <div
+                  className="c8 image-wrapper"
+                >
+                  <img
+                    alt="children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education."
+                    src="//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png"
+                  />
+                </div>
+                <div
+                  className="all-text-wrapper"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <h1
+                      className="c10"
+                    >
+                      5,000
+                    </h1>
+                  </div>
+                  <div
+                    className="c11"
+                  >
+                    <p
+                      className="c12"
+                    >
+                      children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={false}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              >
+                <div
+                  className="c8 image-wrapper"
+                >
+                  <img
+                    alt="children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education."
+                    src="//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png"
+                  />
+                </div>
+                <div
+                  className="all-text-wrapper"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <h1
+                      className="c10"
+                    >
+                      6,000
+                    </h1>
+                  </div>
+                  <div
+                    className="c11"
+                  >
+                    <p
+                      className="c12"
+                    >
+                      children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={false}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              >
+                <div
+                  className="c8 image-wrapper"
+                >
+                  <img
+                    alt="children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education."
+                    src="//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png"
+                  />
+                </div>
+                <div
+                  className="all-text-wrapper"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <h1
+                      className="c10"
+                    >
+                      7,000
+                    </h1>
+                  </div>
+                  <div
+                    className="c11"
+                  >
+                    <p
+                      className="c12"
+                    >
+                      children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={false}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              >
+                <div
+                  className="c8 image-wrapper"
+                >
+                  <img
+                    alt="children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education."
+                    src="//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png"
+                  />
+                </div>
+                <div
+                  className="all-text-wrapper"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <h1
+                      className="c10"
+                    >
+                      8,000
+                    </h1>
+                  </div>
+                  <div
+                    className="c11"
+                  >
+                    <p
+                      className="c12"
+                    >
+                      children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={false}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden last-slide"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              >
+                <div
+                  className="c8 image-wrapper"
+                >
+                  <img
+                    alt="children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education."
+                    src="//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png"
+                  />
+                </div>
+                <div
+                  className="all-text-wrapper"
+                >
+                  <div
+                    className="c9"
+                  >
+                    <h1
+                      className="c10"
+                    >
+                      9,000
+                    </h1>
+                  </div>
+                  <div
+                    className="c11"
+                  >
+                    <p
+                      className="c12"
+                    >
+                      children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              aria-label="slide"
+              aria-selected={false}
+              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
+              onBlur={[Function]}
+              onFocus={[Function]}
+              role="option"
+              style={
+                Object {
+                  "paddingBottom": "36.36363636363637%",
+                  "width": "9.090909090909092%",
+                }
+              }
+              tabIndex={-1}
+            >
+              <div
+                className="slideInner___2mfX9 carousel__inner-slide"
+                style={Object {}}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <button
+        aria-label="previous"
+        className="buttonBack___1mlaL carousel__back-button"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Back
+      </button>
+      <button
+        aria-label="next"
+        className="buttonNext___2mOCa carousel__next-button"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        Next
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renders the default padding version correctly: 
+    .c1 {
+      font-size: 1rem;
+      line-height: 1rem;
+      text-transform: inherit;
+      font-weight: bold;
+      line-height: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+    }
+
+    .c3 {
+      color: #E52630;
+      font-size: 1rem;
+      line-height: 1rem;
+      text-transform: uppercase;
+      font-weight: normal;
+      font-family: 'Anton',Impact,sans-serif;
+      -webkit-letter-spacing: 0.03rem;
+      -moz-letter-spacing: 0.03rem;
+      -ms-letter-spacing: 0.03rem;
+      letter-spacing: 0.03rem;
+    }
+
+    .c5 {
+      font-size: 1rem;
+      line-height: 1rem;
+      text-transform: inherit;
+      line-height: normal;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+    }
+
+    .c2 {
+      width: 75%;
+      margin: 0 auto;
+    }
+
+    .c2:first-child {
+      margin-bottom: 2rem;
+      text-align: center;
+      font-size: 16px;
+      line-height: 19.5px;
+    }
+
+    .c4 {
+      margin-bottom: 2rem;
+      text-align: center;
+      font-size: 34px;
+      line-height: 37px;
+    }
+
+    .c6 {
+      margin-bottom: 0;
+      text-align: center;
+      font-size: 12px;
+      line-height: 14.63px;
+    }
+
+    .c0 {
+      height: 100%;
+      background-color: #FFFFFF;
+      max-width: 760px;
+      padding: 2rem;
+      margin: 0 auto;
+      border-radius: 20px;
+      box-shadow: 0px 0px 20px rgba(0,0,0,0.15);
+    }
+
+    .c0 .carousel {
+      position: relative;
+      margin: 0 auto;
+      padding-top: 2rem;
+    }
+
+    .c0 .carousel button.carousel__back-button,
+    .c0 .carousel button.carousel__next-button {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 33% !important;
+      height: 100%;
+      padding: 0 !important;
+      box-shadow: none;
+      text-indent: -9999px;
+      background-color: transparent;
+      border: none;
+    }
+
+    .c0 .carousel button.carousel__back-button:after,
+    .c0 .carousel button.carousel__next-button:after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 50%;
+      height: 100%;
+      -webkit-transition: opacity 0.2s linear;
+      transition: opacity 0.2s linear;
+      background: linear-gradient(90deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
+    }
+
+    .c0 .carousel button.carousel__back-button:hover:after,
+    .c0 .carousel button.carousel__next-button:hover:after {
+      opacity: 0.5;
+    }
+
+    .c0 .carousel button.carousel__next-button {
+      left: auto;
+      right: 0;
+    }
+
+    .c0 .carousel button.carousel__next-button:before {
+      -webkit-transform: translate(0,-50%) rotate(-90deg);
+      -ms-transform: translate(0,-50%) rotate(-90deg);
+      transform: translate(0,-50%) rotate(-90deg);
+    }
+
+    .c0 .carousel button.carousel__next-button:after {
+      left: auto;
+      right: 0;
+      background: linear-gradient(270deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
+    }
+
+    .c0 .carousel .wymd-carousel {
+      -webkit-transition: -webkit-transform 0.75s;
+      -webkit-transition: -webkit-transform 0.75s;
+      transition: -webkit-transform 0.75s;
+      -o-transition: transform 0.75s;
+      -webkit-transition: -webkit-transform 0.75s;
+      -webkit-transition: transform 0.75s;
+      transition: transform 0.75s;
+      -webkit-transform: 0.75s;
+      will-change: transform;
+    }
+
+    .c0 .carousel .wymd-carousel .last-slide .image-wrapper:after {
+      content: none;
+    }
+
+    .c0 .carousel .wymd-carousel .carousel__slide {
+      padding-bottom: 425px !important;
+    }
+
+    .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide {
+      text-align: center;
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-box-pack: start;
+      -webkit-justify-content: flex-start;
+      -ms-flex-pack: start;
+      justify-content: flex-start;
+      -webkit-flex-direction: column;
+      -ms-flex-direction: column;
+      flex-direction: column;
+    }
+
+    @media (min-width:1024px) {
+      .c2:first-child {
+        font-size: 20px;
+        line-height: 24.38px;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c4 {
+        font-size: 60px;
+        line-height: 60px;
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c4 {
+        font-size: 64px;
+        line-height: 68px;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c6 {
+        font-size: 17px;
+        line-height: 19px;
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c0 .carousel {
+        padding-top: 2rem;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c0 .carousel button.carousel__back-button,
+      .c0 .carousel button.carousel__next-button {
+        width: 33.3% !important;
+      }
+
+      .c0 .carousel button.carousel__back-button:after,
+      .c0 .carousel button.carousel__next-button:after {
+        width: 100%;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c0 .carousel .wymd-carousel .carousel__slide {
+        padding-bottom: 450px !important;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child {
+        -webkit-transition: -webkit-transform 0.75s ease;
+        -webkit-transition: transform 0.75s ease;
+        transition: transform 0.75s ease;
+        -webkit-transform: scale(0.5);
+        -ms-transform: scale(0.5);
+        transform: scale(0.5);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child:after {
+        -webkit-transition: -webkit-transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+        -webkit-transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+        transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+        right: calc(-300% - 6px);
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+        width: 300%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide .all-text-wrapper {
+        -webkit-transition: -webkit-transform 0.75s ease;
+        -webkit-transition: transform 0.75s ease;
+        transition: transform 0.75s ease;
+        -webkit-transform-origin: top;
+        -ms-transform-origin: top;
+        transform-origin: top;
+        -webkit-transform: translateY(calc(-45px + 5%)) scale(0.5);
+        -ms-transform: translateY(calc(-45px + 5%)) scale(0.5);
+        transform: translateY(calc(-45px + 5%)) scale(0.5);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-300% - 6px);
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+        width: 300%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child {
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-222% - 6px);
+        -webkit-transform: scale(0.5);
+        -ms-transform: scale(0.5);
+        transform: scale(0.5);
+        width: 300%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
+        -webkit-transform: translateY(0) scale(1);
+        -ms-transform: translateY(0) scale(1);
+        transform: translateY(0) scale(1);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child {
+        -webkit-transform: scale(0.5);
+        -ms-transform: scale(0.5);
+        transform: scale(0.5);
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child:after {
+        right: calc(-300% - 6px);
+        -webkit-transform: scale(1);
+        -ms-transform: scale(1);
+        transform: scale(1);
+        width: 300%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
+        -webkit-transform: translateY(calc(-45px + 5%)) scale(0.5);
+        -ms-transform: translateY(calc(-45px + 5%)) scale(0.5);
+        transform: translateY(calc(-45px + 5%)) scale(0.5);
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c0 .carousel .wymd-carousel .carousel__slide {
+        padding-bottom: 475px !important;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-250% - 6px);
+        width: 250%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-187% - 6px);
+        width: 250%;
+      }
+
+      .c0 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+        right: calc(-250% - 6px);
+        width: 250%;
+      }
+    }
+
+    <div
+      className="c0 CarouselWrapper"
+      id="7zdR84QkZwrTh9NWx2H926"
+    >
+      <p
+        className="c1 c2"
+        color="inherit"
+        size="s"
+      >
+        Over the past two years, we’ve supported
+      </p>
+      <h1
+        className="c3 c4"
+        color="red"
+        size="s"
+      >
+        11.7 million people
+      </h1>
+      <p
+        className="c5 c6"
+        color="inherit"
+        size="s"
+      >
+        including...
+      </p>
+    </div>
+   1`] = `
+.c2 {
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  font-size: 1rem;
+  line-height: 1.25rem;
+}
+
+.c2 {
+  font-weight: bold;
+}
+
+.c2 span {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.c4 {
+  font-family: 'Anton',Impact,sans-serif;
+  font-weight: 400;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  font-size: 2rem;
+  line-height: 2rem;
+}
+
+.c4 {
+  font-family: 'Anton',Impact,sans-serif;
+  font-weight: normal;
+  color: #E52630;
+}
+
+.c4 span {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.c6 {
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  font-size: 1rem;
+  line-height: 1.25rem;
+}
+
+.c6 span {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.c3 {
+  width: 75%;
+  margin: 0 auto;
+}
+
+.c3:first-child {
+  margin-bottom: 2rem;
+  text-align: center;
+  font-size: 16px;
+  line-height: 19.5px;
+}
+
+.c5 {
+  margin-bottom: 2rem;
+  text-align: center;
+  font-size: 34px;
+  line-height: 37px;
+}
+
+.c7 {
+  margin-bottom: 0;
+  text-align: center;
+  font-size: 12px;
+  line-height: 14.63px;
+}
+
+.c1 {
+  height: 100%;
+  background-color: #FFFFFF;
+  max-width: 760px;
+  padding: 2rem;
+  margin: 0 auto;
+  border-radius: 20px;
+  box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
+}
+
+.c1 .carousel {
+  position: relative;
+  margin: 0 auto;
+  padding-top: 2rem;
+}
+
+.c1 .carousel button.carousel__back-button,
+.c1 .carousel button.carousel__next-button {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 33% !important;
+  height: 100%;
+  padding: 0 !important;
+  box-shadow: none;
+  text-indent: -9999px;
+  background-color: transparent;
+  border: none;
+}
+
+.c1 .carousel button.carousel__back-button:after,
+.c1 .carousel button.carousel__next-button:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  height: 100%;
+  -webkit-transition: opacity 0.2s linear;
+  transition: opacity 0.2s linear;
+  background: linear-gradient(90deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
+}
+
+.c1 .carousel button.carousel__back-button:hover:after,
+.c1 .carousel button.carousel__next-button:hover:after {
+  opacity: 0.5;
+}
+
+.c1 .carousel button.carousel__next-button {
+  left: auto;
+  right: 0;
+}
+
+.c1 .carousel button.carousel__next-button:before {
+  -webkit-transform: translate(0,-50%) rotate(-90deg);
+  -ms-transform: translate(0,-50%) rotate(-90deg);
+  transform: translate(0,-50%) rotate(-90deg);
+}
+
+.c1 .carousel button.carousel__next-button:after {
+  left: auto;
+  right: 0;
+  background: linear-gradient(270deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
+}
+
+.c1 .carousel .wymd-carousel {
+  -webkit-transition: -webkit-transform 0.75s;
+  -webkit-transition: -webkit-transform 0.75s;
+  transition: -webkit-transform 0.75s;
+  -o-transition: transform 0.75s;
+  -webkit-transition: -webkit-transform 0.75s;
+  -webkit-transition: transform 0.75s;
+  transition: transform 0.75s;
+  -webkit-transform: 0.75s;
+  will-change: transform;
+}
+
+.c1 .carousel .wymd-carousel .last-slide .image-wrapper:after {
+  content: none;
+}
+
+.c1 .carousel .wymd-carousel .carousel__slide {
+  padding-bottom: 425px !important;
+}
+
+.c1 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide {
+  text-align: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c0 {
+  padding: 0rem 0 0rem;
+}
+
+@media (min-width:740px) {
+  .c2 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c4 {
+    font-size: 2.5rem;
+    line-height: 2.5rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    font-size: 3rem;
+    line-height: 3rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c6 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c6 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c3:first-child {
+    font-size: 20px;
+    line-height: 24.38px;
+  }
+}
+
+@media (min-width:740px) {
+  .c5 {
+    font-size: 60px;
+    line-height: 60px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c5 {
+    font-size: 64px;
+    line-height: 68px;
+  }
+}
+
+@media (min-width:740px) {
+  .c7 {
+    font-size: 17px;
+    line-height: 19px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 .carousel {
+    padding-top: 2rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c1 .carousel button.carousel__back-button,
+  .c1 .carousel button.carousel__next-button {
+    width: 33.3% !important;
+  }
+
+  .c1 .carousel button.carousel__back-button:after,
+  .c1 .carousel button.carousel__next-button:after {
+    width: 100%;
+  }
+}
+
+@media (min-width:740px) {
+  .c1 .carousel .wymd-carousel .carousel__slide {
+    padding-bottom: 450px !important;
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child {
+    -webkit-transition: -webkit-transform 0.75s ease;
+    -webkit-transition: transform 0.75s ease;
+    transition: transform 0.75s ease;
+    -webkit-transform: scale(0.5);
+    -ms-transform: scale(0.5);
+    transform: scale(0.5);
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide > div:first-child:after {
+    -webkit-transition: -webkit-transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+    -webkit-transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+    transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+    right: calc(-300% - 6px);
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+    width: 300%;
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide .carousel__inner-slide .all-text-wrapper {
+    -webkit-transition: -webkit-transform 0.75s ease;
+    -webkit-transition: transform 0.75s ease;
+    transition: transform 0.75s ease;
+    -webkit-transform-origin: top;
+    -ms-transform-origin: top;
+    transform-origin: top;
+    -webkit-transform: translateY(calc(-45px + 5%)) scale(0.5);
+    -ms-transform: translateY(calc(-45px + 5%)) scale(0.5);
+    transform: translateY(calc(-45px + 5%)) scale(0.5);
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+    right: calc(-300% - 6px);
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+    width: 300%;
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child {
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+    right: calc(-222% - 6px);
+    -webkit-transform: scale(0.5);
+    -ms-transform: scale(0.5);
+    transform: scale(0.5);
+    width: 300%;
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
+    -webkit-transform: translateY(0) scale(1);
+    -ms-transform: translateY(0) scale(1);
+    transform: translateY(0) scale(1);
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child {
+    -webkit-transform: scale(0.5);
+    -ms-transform: scale(0.5);
+    transform: scale(0.5);
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible > div > div:first-child:after {
+    right: calc(-300% - 6px);
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    transform: scale(1);
+    width: 300%;
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .all-text-wrapper {
+    -webkit-transform: translateY(calc(-45px + 5%)) scale(0.5);
+    -ms-transform: translateY(calc(-45px + 5%)) scale(0.5);
+    transform: translateY(calc(-45px + 5%)) scale(0.5);
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 .carousel .wymd-carousel .carousel__slide {
+    padding-bottom: 475px !important;
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+    right: calc(-250% - 6px);
+    width: 250%;
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+    right: calc(-187% - 6px);
+    width: 250%;
+  }
+
+  .c1 .carousel .wymd-carousel .carousel__slide.carousel__slide--visible + .carousel__slide--visible + .carousel__slide--visible .carousel__inner-slide > div:first-child:after {
+    right: calc(-250% - 6px);
+    width: 250%;
+  }
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1 CarouselWrapper"
+    id="7zdR84QkZwrTh9NWx2H926"
   >
-    11.7 million people
-  </h1>
-  <p
-    className="c5 c6"
-  >
-    including...
-  </p>
+    <p
+      className="c2 c3"
+    >
+      Over the past two years, we’ve supported
+    </p>
+    <h1
+      className="c4 c5"
+    >
+      11.7 million people
+    </h1>
+    <p
+      className="c6 c7"
+    >
+      including...
+    </p>
+  </div>
 </div>
 `;

--- a/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
+++ b/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
@@ -415,35 +415,10 @@ exports[`renders the customised padding version correctly:
 }
 
 .c10 {
-  font-size: 1rem;
-  line-height: normal;
   font-family: 'Anton',Impact,sans-serif;
-  font-weight: normal;
 }
 
 .c10 span {
-  font-size: inherit;
-  line-height: inherit;
-}
-
-.c12 {
-  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
-  font-weight: 400;
-  text-transform: inherit;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  font-size: 1rem;
-  line-height: 1.25rem;
-}
-
-.c12 {
-  font-size: 1rem;
-  line-height: normal;
-}
-
-.c12 span {
   font-size: inherit;
   line-height: inherit;
 }
@@ -682,20 +657,6 @@ exports[`renders the customised padding version correctly:
   .c10 {
     font-size: 3rem;
     line-height: 3rem;
-  }
-}
-
-@media (min-width:740px) {
-  .c12 {
-    font-size: 1rem;
-    line-height: 1.25rem;
-  }
-}
-
-@media (min-width:1024px) {
-  .c12 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
   }
 }
 
@@ -988,7 +949,7 @@ exports[`renders the customised padding version correctly:
                     className="c11"
                   >
                     <p
-                      className="c12"
+                      className="c6"
                     >
                       children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                     </p>
@@ -1039,7 +1000,7 @@ exports[`renders the customised padding version correctly:
                     className="c11"
                   >
                     <p
-                      className="c12"
+                      className="c6"
                     >
                       children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                     </p>
@@ -1090,7 +1051,7 @@ exports[`renders the customised padding version correctly:
                     className="c11"
                   >
                     <p
-                      className="c12"
+                      className="c6"
                     >
                       children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                     </p>
@@ -1141,7 +1102,7 @@ exports[`renders the customised padding version correctly:
                     className="c11"
                   >
                     <p
-                      className="c12"
+                      className="c6"
                     >
                       children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                     </p>
@@ -1192,7 +1153,7 @@ exports[`renders the customised padding version correctly:
                     className="c11"
                   >
                     <p
-                      className="c12"
+                      className="c6"
                     >
                       children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                     </p>
@@ -1243,7 +1204,7 @@ exports[`renders the customised padding version correctly:
                     className="c11"
                   >
                     <p
-                      className="c12"
+                      className="c6"
                     >
                       children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                     </p>
@@ -1294,7 +1255,7 @@ exports[`renders the customised padding version correctly:
                     className="c11"
                   >
                     <p
-                      className="c12"
+                      className="c6"
                     >
                       children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                     </p>
@@ -1345,7 +1306,7 @@ exports[`renders the customised padding version correctly:
                     className="c11"
                   >
                     <p
-                      className="c12"
+                      className="c6"
                     >
                       children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                     </p>
@@ -1396,7 +1357,7 @@ exports[`renders the customised padding version correctly:
                     className="c11"
                   >
                     <p
-                      className="c12"
+                      className="c6"
                     >
                       children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                     </p>

--- a/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
+++ b/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
@@ -1982,7 +1982,7 @@ exports[`renders the default padding version correctly:
 }
 
 .c0 {
-  padding: 0rem 0 0rem;
+  padding: 2rem 0 2rem;
 }
 
 @media (min-width:740px) {

--- a/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
+++ b/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
@@ -625,6 +625,7 @@ exports[`renders the customised padding version correctly:
 }
 
 .c0 {
+  background-color: #86E4E9;
   padding: 4rem 0 4rem;
 }
 
@@ -1982,6 +1983,7 @@ exports[`renders the default padding version correctly:
 }
 
 .c0 {
+  background-color: #F4F3F5;
   padding: 2rem 0 2rem;
 }
 

--- a/src/styleguide/data/data.js
+++ b/src/styleguide/data/data.js
@@ -127,6 +127,82 @@ const carouselItemsComplete = {
   }
 };
 
+const carouselItemsCompleteWithPadding = {
+  __typename: 'ContentfulWhatYourMoneyDoesCarousel',
+  contentful_id: '7zdR84QkZwrTh9NWx2H926',
+  mobileHeight: 425,
+  tabletHeight: 450,
+  desktopHeight: 475,
+  headerCopy: 'Over the past two years, we’ve supported',
+  peopleHelpedText: '11.7 million people',
+  autoPlay: false,
+  paddingBottom: '4rem',
+  paddingTop: '4rem',
+  node1Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
+  node1Amount: '1,000',
+  node1Image: {
+    file: {
+      url: '//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png'
+    }
+  },
+  node2Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
+  node2Amount: '750,000',
+  node2Image: {
+    file: {
+      url: '//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png'
+    }
+  },
+  node3Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
+  node3Amount: '3,000',
+  node3Image: {
+    file: {
+      url: '//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png'
+    }
+  },
+  node4Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
+  node4Amount: '4,000',
+  node4Image: {
+    file: {
+      url: '//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png'
+    }
+  },
+  node5Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
+  node5Amount: '5,000',
+  node5Image: {
+    file: {
+      url: '//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png'
+    }
+  },
+  node6Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
+  node6Amount: '6,000',
+  node6Image: {
+    file: {
+      url: '//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png'
+    }
+  },
+  node7Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
+  node7Amount: '7,000',
+  node7Image: {
+    file: {
+      url: '//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png'
+    }
+  },
+  node8Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
+  node8Amount: '8,000',
+  node8Image: {
+    file: {
+      url: '//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png'
+    }
+  },
+  node9Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
+  node9Amount: '9,000',
+  node9Image: {
+    file: {
+      url: '//images.ctfassets.net/zsfivwzfgl3t/6ZsS5CpukQwXRcMSUlbOM1/be31c7ff09891d14232e7c3dbe9fa8a2/028-love_1.png'
+    }
+  }
+};
+
 const carouselItemsIncomplete = {
   __typename: 'ContentfulWhatYourMoneyDoesCarousel',
   contentful_id: '7zdR84QkZwrTh9NWx2H9262',
@@ -242,5 +318,6 @@ const RichtextCarouselItems = {
 
 export {
   defaultData, mobileImages, testImpactSliderItems,
-  carouselItemsComplete, carouselItemsIncomplete, carouselItemsMinimal, RichtextCarouselItems
+  carouselItemsComplete, carouselItemsCompleteWithPadding,
+  carouselItemsIncomplete, carouselItemsMinimal, RichtextCarouselItems
 };

--- a/src/styleguide/data/data.js
+++ b/src/styleguide/data/data.js
@@ -138,6 +138,7 @@ const carouselItemsCompleteWithPadding = {
   autoPlay: false,
   paddingBottom: '4rem',
   paddingTop: '4rem',
+  backgroundColour: 'teal_light',
   node1Copy: 'children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.',
   node1Amount: '1,000',
   node1Image: {

--- a/src/styleguide/data/data.js
+++ b/src/styleguide/data/data.js
@@ -316,8 +316,24 @@ const RichtextCarouselItems = {
   autoPlay: true
 };
 
+const RichtextCarouselItemsWithPadding = {
+  contentful_id: 'nqIEHjiYE8Yd2A2a5cI31',
+  headingCopy: 'Some heading copy that will be nicely constructed in-situ',
+  nodes: [
+    { copy: 'Some other longside but not really all that long copy, who knows, it could be this long or LESS.' },
+    { copy: '140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets.' },
+    { copy: 'Some other longside but not really all that long copy, who knows, it could be this long or LESS' },
+    { copy: '140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets. ABIGLONGLINETOFORCEONTOANEWONE' }
+  ],
+  autoPlay: true,
+  paddingBottom: '4rem',
+  paddingTop: '4rem',
+  rowBackgroundColour: 'teal_light'
+};
+
 export {
   defaultData, mobileImages, testImpactSliderItems,
   carouselItemsComplete, carouselItemsCompleteWithPadding,
-  carouselItemsIncomplete, carouselItemsMinimal, RichtextCarouselItems
+  carouselItemsIncomplete, carouselItemsMinimal,
+  RichtextCarouselItems, RichtextCarouselItemsWithPadding
 };


### PR DESCRIPTION
### PR description
#### What is it doing?
Sets up and uses new padding fields to be added to the WYMD and RichText carousel CMS content models shortly.

The CRcom integrations have a similar wrapping divs that add the background-colour and some now-outdated padding options, so I decided while I was here to extend the component itself to keep all of those customisations "in-house", for more clarity and ease of testing, removing said wrappers once this is integrated.

#### Why is this required?
Website Project

#### link to Jira ticket:
https://comicrelief.atlassian.net/browse/ENG-4997 and
https://comicrelief.atlassian.net/browse/ENG-4996

### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
