### PR TITLE
fix: Amend behaviour of ambient video control button

### DIFF
--- a/src/components/Atoms/AmbientVideo/AmbientVideo.style.js
+++ b/src/components/Atoms/AmbientVideo/AmbientVideo.style.js
@@ -78,7 +78,7 @@ const PlayPauseButton = styled.button`
   align-items: center;
   justify-content: center;
   opacity: 0;
-  transition: opacity 0.2s ease 2s;
+  transition: opacity 0.2s ease 3s;
   ${zIndex('high')};
 
   // Play icon is shifted to the right slightly as it

--- a/src/components/Atoms/AmbientVideo/AmbientVideo.style.js
+++ b/src/components/Atoms/AmbientVideo/AmbientVideo.style.js
@@ -1,6 +1,18 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 import zIndex from '../../../theme/shared/zIndex';
+
+// This is so that the button is initially visible, then afterwards
+// it's only seen again on hover
+const playPauseIntro = keyframes`
+  0%,
+  93.75% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 0;
+  }
+`;
 
 const Wrapper = styled.div`
   width: 100%;
@@ -78,6 +90,7 @@ const PlayPauseButton = styled.button`
   align-items: center;
   justify-content: center;
   opacity: 0;
+  animation: ${playPauseIntro} 3s ease;
   transition: opacity 0.2s ease 3s;
   ${zIndex('high')};
 

--- a/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
+++ b/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
@@ -62,6 +62,8 @@ exports[`renders AmbientVideo when video props are provided correctly 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   opacity: 0;
+  -webkit-animation: diKSqD 3s ease;
+  animation: diKSqD 3s ease;
   -webkit-transition: opacity 0.2s ease 3s;
   transition: opacity 0.2s ease 3s;
   z-index: 3;

--- a/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
+++ b/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
@@ -62,8 +62,8 @@ exports[`renders AmbientVideo when video props are provided correctly 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   opacity: 0;
-  -webkit-transition: opacity 0.2s ease 2s;
-  transition: opacity 0.2s ease 2s;
+  -webkit-transition: opacity 0.2s ease 3s;
+  transition: opacity 0.2s ease 3s;
   z-index: 3;
 }
 


### PR DESCRIPTION
### PR description
#### What is it doing?
Two amendments to the behaviour of play/pause button for ambient video, following Curtis' review:
1. Increase fadeout from 2s to 3s
2. Make the button appear on initial load, so the user knows it's there

#### Why is this required?
Design QA

#### link to Jira ticket:
[ENG-5006]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5006]: https://comicrelief.atlassian.net/browse/ENG-5006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ