### PR TITLE
fix: Stop StyledVideo from loading both video files

### DIFF
--- a/src/components/Atoms/AmbientVideo/AmbientVideo.js
+++ b/src/components/Atoms/AmbientVideo/AmbientVideo.js
@@ -20,6 +20,8 @@ import {
 // Normalise webpack module object ({ default }) or string to video URL
 const normaliseSrc = value => (typeof value === 'string' ? value : value?.default);
 
+const belowLBreakpointMediaString = `(max-width: ${breakpointValues.L - 1}px)`;
+
 const AmbientVideo = ({
   src,
   srcMobile,
@@ -32,8 +34,9 @@ const AmbientVideo = ({
   const videoRef = useRef(null);
   const [isPlaying, setIsPlaying] = useState(true);
   const isBelowL = useMediaQuery({ maxWidth: breakpointValues.L - 1 });
-  const rawSrc = srcMobile && isBelowL ? srcMobile : src;
-  const effectiveSrc = normaliseSrc(rawSrc);
+  const desktopSrc = normaliseSrc(src);
+  const mobileSrc = srcMobile ? normaliseSrc(srcMobile) : null;
+  // <video> only supports one poster URL; keep JS breakpoint for poster / fallback stills.
   const rawPoster = posterMobile && isBelowL ? posterMobile : poster;
   const effectivePoster = rawPoster ? normaliseSrc(rawPoster) : undefined;
 
@@ -72,7 +75,6 @@ const AmbientVideo = ({
     <VideoWrapper>
       <StyledVideo
         ref={videoRef}
-        src={effectiveSrc}
         poster={effectivePoster}
         controls={showFullControls}
         controlsList={showFullControls ? 'nodownload nofullscreen noremoteplayback' : undefined}
@@ -82,6 +84,10 @@ const AmbientVideo = ({
         onPlay={handlePlay}
         onPause={handlePause}
       >
+        {mobileSrc ? (
+          <source src={mobileSrc} type="video/mp4" media={belowLBreakpointMediaString} />
+        ) : null}
+        <source src={desktopSrc} type="video/mp4" />
         {effectivePoster ? (
           <FallbackImg src={effectivePoster} alt="Video playback not supported" />
         ) : (

--- a/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
+++ b/src/components/Molecules/PictureOrVideo/__snapshots__/PictureOrVideo.test.js.snap
@@ -122,8 +122,16 @@ exports[`renders AmbientVideo when video props are provided correctly 1`] = `
     onPlay={[Function]}
     playsInline={true}
     poster="//images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg?w=200&h=150&q=50 200w,//images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg?w=400&h=300&q=50 400w,//images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg?w=800&h=600&q=50 800w,//images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg?w=1200&h=900&q=50 1200w,//images.ctfassets.net/zsfivwzfgl3t/Yq59XdwwQgjNOxky93K1Q/17c2d80dce99067b0b3508f33075cbe3/funding_4-3_2x.jpg?w=1440&h=1080&q=50 1440w"
-    src="https://example.com/video-desktop.mp4"
   >
+    <source
+      media="(max-width: 1023px)"
+      src="https://example.com/video-mobile.mp4"
+      type="video/mp4"
+    />
+    <source
+      src="https://example.com/video-desktop.mp4"
+      type="video/mp4"
+    />
     <img
       alt="Video playback not supported"
       className="c3"


### PR DESCRIPTION
### PR description
#### What is it doing?
Addresses an issue where mobile users were loading in both video files.
I believe it's because Gatsby compiles its files not knowing the viewport size, and went with the default desktop URL. Once rendered, react recalculates with the real viewport, and switches the video to mobile. This meant the user was downloading both files.

Now, the AmbientVideo component makes use of `<source>`. There are two in order and the browser will use the first one that's valid. 
This should mean that React won't need to recompute anything. The browser will know what to do correctly when it first loads.

I've given it a test on CRCom and it appears to fix the bug.

#### Why is this required?
Bugfix, optimisation.

#### link to Jira ticket:
[ENG-5050]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5050]: https://comicrelief.atlassian.net/browse/ENG-5050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ