### PR TITLE
fix: Relax validation of names, to allow special characters, apostrophes and hyphens

### DIFF
--- a/src/components/Organisms/EmailSignUp/EmailSignUp.test.js
+++ b/src/components/Organisms/EmailSignUp/EmailSignUp.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import "jest-styled-components";
 import renderWithTheme from "../../../../tests/hoc/shallowWithTheme";
-import { EmailSignUp, validationSchema } from "./_EmailSignUp";
+import { EmailSignUp, buildEsuValidationSchema } from "./_EmailSignUp";
 import RichText from "../../Atoms/RichText/RichText";
 import { useForm, FormProvider } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -9,7 +9,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 const DummyForm = () => {
   const formMethods = useForm({
     mode: "onBlur",
-    resolver: yupResolver(validationSchema),
+    resolver: yupResolver(buildEsuValidationSchema()),
   });
   const { handleSubmit } = formMethods;
 

--- a/src/components/Organisms/shared/emailSignup/emailSignupConfig.js
+++ b/src/components/Organisms/shared/emailSignup/emailSignupConfig.js
@@ -34,7 +34,7 @@ const buildEsuValidationSchema = overrides => {
       .string()
       .required('Please enter your first name')
       .matches(
-        /^[A-Za-z][A-Za-z' -]*$/,
+        /^\p{L}[\p{L}' -]*$/u,
         "This field only accepts letters and ' - and must start with a letter"
       )
       .max(25, 'Your first name must be between 1 and 25 characters'),
@@ -42,7 +42,7 @@ const buildEsuValidationSchema = overrides => {
       .string()
       .required('Please enter your last name')
       .matches(
-        /^[A-Za-z][A-Za-z' -]*$/,
+        /^\p{L}[\p{L}' -]*$/u,
         "This field only accepts letters and ' - and must start with a letter"
       )
       .max(50, 'Your last name must be between 1 and 50 characters'),

--- a/src/components/Organisms/shared/emailSignup/emailSignupConfig.test.js
+++ b/src/components/Organisms/shared/emailSignup/emailSignupConfig.test.js
@@ -1,0 +1,19 @@
+import { buildEsuValidationSchema, ESU_FIELDS } from './emailSignupConfig';
+
+describe('buildEsuValidationSchema', () => {
+  const schema = buildEsuValidationSchema({});
+
+  it('accepts first and last names with accented Latin letters', async () => {
+    await expect(
+      schema.validate({
+        [ESU_FIELDS.FIRST_NAME]: 'André',
+        [ESU_FIELDS.LAST_NAME]: 'François',
+        [ESU_FIELDS.EMAIL]: 'andre.francois@example.com'
+      })
+    ).resolves.toEqual({
+      [ESU_FIELDS.FIRST_NAME]: 'André',
+      [ESU_FIELDS.LAST_NAME]: 'François',
+      [ESU_FIELDS.EMAIL]: 'andre.francois@example.com'
+    });
+  });
+});


### PR DESCRIPTION
### PR description
#### What is it doing?
José
André
Müller
François
All people who cannot currently put their proper names into ESU. 
This change will relax the name regex to look for 'Letters' as defined by Unicode, rather than strictly A-Z only, which will allow characters with diacritics like those above. Also, it will allow names with apostrophes and hyphens, like J-Train and D'Snazzle. 

#### Why is this required?
We have been adopting a similar approach elsewhere, like with FSU, so this brings some consistency.

#### link to Jira ticket:
[ENG-5017]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [ ] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5017]: https://comicrelief.atlassian.net/browse/ENG-5017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ