### PR TITLE
fix: Reduce Input field font size and padding

### DIFF
--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -6,6 +6,7 @@ import alertIcon from './assets/error-alert-icon-red.svg';
 import Label from '../Label/Label';
 import ErrorText from '../ErrorText/ErrorText';
 import zIndex from '../../../theme/shared/zIndex';
+import fontHelper from '../../../theme/crTheme/fontHelper';
 
 // This seems to get a decent approximation of the necessary width (without resorting to measuring
 //  the element with JS)
@@ -13,7 +14,7 @@ const getPrefixWidth = prefixLength => `calc(1.5rem + (${prefixLength} * 0.5rem)
 
 const InputWrapper = styled.div`
   position: relative;
-  font-size: ${({ theme }) => theme.fontSize('s')};
+  ${({ theme }) => fontHelper(theme, 'span')}
 `;
 
 const InputFieldContainer = styled.div`

--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -13,7 +13,7 @@ const getPrefixWidth = prefixLength => `calc(1.5rem + (${prefixLength} * 0.5rem)
 
 const InputWrapper = styled.div`
   position: relative;
-  font-size: ${({ theme }) => theme.fontSize('m')};
+  font-size: ${({ theme }) => theme.fontSize('s')};
 `;
 
 const InputFieldContainer = styled.div`
@@ -38,7 +38,7 @@ const InputField = styled.input`${({ theme, error, prefixLength }) => css`
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   ${prefixLength > 0 ? `padding-left: ${getPrefixWidth(prefixLength)};` : ''}
   background-color: ${theme.color('grey_light')};
   border: 1px solid;

--- a/src/components/Atoms/Input/Input.js
+++ b/src/components/Atoms/Input/Input.js
@@ -14,7 +14,7 @@ const getPrefixWidth = prefixLength => `calc(1.5rem + (${prefixLength} * 0.5rem)
 
 const InputWrapper = styled.div`
   position: relative;
-  ${({ theme }) => fontHelper(theme, 'span')}
+  ${({ theme }) => fontHelper(theme, 'formFieldInput')}
 `;
 
 const InputFieldContainer = styled.div`

--- a/src/components/Atoms/Input/input.test.js
+++ b/src/components/Atoms/Input/input.test.js
@@ -61,7 +61,7 @@ it('renders correctly', () => {
 
     .c3 {
       position: relative;
-      font-size: 1.25rem;
+      font-size: 1rem;
     }
 
     .c4 {
@@ -86,7 +86,7 @@ it('renders correctly', () => {
       box-sizing: border-box;
       width: 100%;
       height: 48px;
-      padding: 1rem 2.4rem 1rem 1.5rem;
+      padding: 1rem;
       background-color: #F4F3F5;
       border: 1px solid;
       border-color: #969598;
@@ -236,7 +236,7 @@ it('renders with responsive max widths correctly', () => {
 
     .c3 {
       position: relative;
-      font-size: 1.25rem;
+      font-size: 1rem;
     }
 
     .c4 {
@@ -261,7 +261,7 @@ it('renders with responsive max widths correctly', () => {
       box-sizing: border-box;
       width: 100%;
       height: 48px;
-      padding: 1rem 2.4rem 1rem 1.5rem;
+      padding: 1rem;
       background-color: #F4F3F5;
       border: 1px solid;
       border-color: #969598;

--- a/src/components/Atoms/Input/input.test.js
+++ b/src/components/Atoms/Input/input.test.js
@@ -61,7 +61,15 @@ it('renders correctly', () => {
 
     .c3 {
       position: relative;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+      font-weight: 400;
+      text-transform: inherit;
+      -webkit-letter-spacing: 0;
+      -moz-letter-spacing: 0;
+      -ms-letter-spacing: 0;
+      letter-spacing: 0;
       font-size: 1rem;
+      line-height: 1.25rem;
     }
 
     .c4 {
@@ -130,6 +138,20 @@ it('renders correctly', () => {
       .c2 {
         font-size: 1rem;
         line-height: 1.25rem;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c3 {
+        font-size: 1rem;
+        line-height: 1.25rem;
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c3 {
+        font-size: 1.125rem;
+        line-height: 1.375rem;
       }
     }
 
@@ -236,7 +258,15 @@ it('renders with responsive max widths correctly', () => {
 
     .c3 {
       position: relative;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+      font-weight: 400;
+      text-transform: inherit;
+      -webkit-letter-spacing: 0;
+      -moz-letter-spacing: 0;
+      -ms-letter-spacing: 0;
+      letter-spacing: 0;
       font-size: 1rem;
+      line-height: 1.25rem;
     }
 
     .c4 {
@@ -305,6 +335,20 @@ it('renders with responsive max widths correctly', () => {
       .c2 {
         font-size: 1rem;
         line-height: 1.25rem;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c3 {
+        font-size: 1rem;
+        line-height: 1.25rem;
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c3 {
+        font-size: 1.125rem;
+        line-height: 1.375rem;
       }
     }
 

--- a/src/components/Atoms/Input/input.test.js
+++ b/src/components/Atoms/Input/input.test.js
@@ -150,8 +150,8 @@ it('renders correctly', () => {
 
     @media (min-width:1024px) {
       .c3 {
-        font-size: 1.125rem;
-        line-height: 1.375rem;
+        font-size: 1.25rem;
+        line-height: 1.25rem;
       }
     }
 
@@ -347,8 +347,8 @@ it('renders with responsive max widths correctly', () => {
 
     @media (min-width:1024px) {
       .c3 {
-        font-size: 1.125rem;
-        line-height: 1.375rem;
+        font-size: 1.25rem;
+        line-height: 1.25rem;
       }
     }
 

--- a/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
+++ b/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
@@ -46,7 +46,15 @@ exports[`renders correctly with no value and no options 1`] = `
 
 .c4 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c5 {
@@ -119,6 +127,20 @@ exports[`renders correctly with no value and no options 1`] = `
   .c3 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c4 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -219,7 +241,15 @@ exports[`renders correctly with value and no options 1`] = `
 
 .c4 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c5 {
@@ -292,6 +322,20 @@ exports[`renders correctly with value and no options 1`] = `
   .c3 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c4 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -392,7 +436,15 @@ exports[`renders correctly with value and options 1`] = `
 
 .c4 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c5 {
@@ -498,6 +550,20 @@ exports[`renders correctly with value and options 1`] = `
   .c3 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c4 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 

--- a/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
+++ b/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
@@ -46,7 +46,7 @@ exports[`renders correctly with no value and no options 1`] = `
 
 .c4 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c5 {
@@ -71,7 +71,7 @@ exports[`renders correctly with no value and no options 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -219,7 +219,7 @@ exports[`renders correctly with value and no options 1`] = `
 
 .c4 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c5 {
@@ -244,7 +244,7 @@ exports[`renders correctly with value and no options 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -392,7 +392,7 @@ exports[`renders correctly with value and options 1`] = `
 
 .c4 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c5 {
@@ -417,7 +417,7 @@ exports[`renders correctly with value and options 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;

--- a/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
+++ b/src/components/Atoms/TextInputWithDropdown/__snapshots__/TextInputWithDropdown.test.js.snap
@@ -139,8 +139,8 @@ exports[`renders correctly with no value and no options 1`] = `
 
 @media (min-width:1024px) {
   .c4 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -334,8 +334,8 @@ exports[`renders correctly with value and no options 1`] = `
 
 @media (min-width:1024px) {
   .c4 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -562,8 +562,8 @@ exports[`renders correctly with value and options 1`] = `
 
 @media (min-width:1024px) {
   .c4 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/src/components/Molecules/SchoolLookup/__snapshots__/SchoolLookup.test.js.snap
+++ b/src/components/Molecules/SchoolLookup/__snapshots__/SchoolLookup.test.js.snap
@@ -46,7 +46,7 @@ exports[`renders correctly 1`] = `
 
 .c4 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c5 {
@@ -71,7 +71,7 @@ exports[`renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;

--- a/src/components/Molecules/SchoolLookup/__snapshots__/SchoolLookup.test.js.snap
+++ b/src/components/Molecules/SchoolLookup/__snapshots__/SchoolLookup.test.js.snap
@@ -139,8 +139,8 @@ exports[`renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c4 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/src/components/Molecules/SchoolLookup/__snapshots__/SchoolLookup.test.js.snap
+++ b/src/components/Molecules/SchoolLookup/__snapshots__/SchoolLookup.test.js.snap
@@ -46,7 +46,15 @@ exports[`renders correctly 1`] = `
 
 .c4 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c5 {
@@ -119,6 +127,20 @@ exports[`renders correctly 1`] = `
   .c3 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c4 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 

--- a/src/components/Molecules/SearchInput/SearchInput.test.js
+++ b/src/components/Molecules/SearchInput/SearchInput.test.js
@@ -173,8 +173,8 @@ it('renders correctly', () => {
 
     @media (min-width:1024px) {
       .c8 {
-        font-size: 1.125rem;
-        line-height: 1.375rem;
+        font-size: 1.25rem;
+        line-height: 1.25rem;
       }
     }
 

--- a/src/components/Molecules/SearchInput/SearchInput.test.js
+++ b/src/components/Molecules/SearchInput/SearchInput.test.js
@@ -62,7 +62,15 @@ it('renders correctly', () => {
 
     .c8 {
       position: relative;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+      font-weight: 400;
+      text-transform: inherit;
+      -webkit-letter-spacing: 0;
+      -moz-letter-spacing: 0;
+      -ms-letter-spacing: 0;
+      letter-spacing: 0;
       font-size: 1rem;
+      line-height: 1.25rem;
     }
 
     .c9 {
@@ -151,6 +159,20 @@ it('renders correctly', () => {
 
     @media (min-width:1024px) {
       .c6 {
+        font-size: 1.125rem;
+        line-height: 1.375rem;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c8 {
+        font-size: 1rem;
+        line-height: 1.25rem;
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c8 {
         font-size: 1.125rem;
         line-height: 1.375rem;
       }

--- a/src/components/Molecules/SearchInput/SearchInput.test.js
+++ b/src/components/Molecules/SearchInput/SearchInput.test.js
@@ -62,7 +62,7 @@ it('renders correctly', () => {
 
     .c8 {
       position: relative;
-      font-size: 1.25rem;
+      font-size: 1rem;
     }
 
     .c9 {
@@ -87,7 +87,7 @@ it('renders correctly', () => {
       box-sizing: border-box;
       width: 100%;
       height: 48px;
-      padding: 1rem 2.4rem 1rem 1.5rem;
+      padding: 1rem;
       background-color: #F4F3F5;
       border: 1px solid;
       border-color: #969598;

--- a/src/components/Molecules/Typeahead/__snapshots__/Typeahead.test.js.snap
+++ b/src/components/Molecules/Typeahead/__snapshots__/Typeahead.test.js.snap
@@ -46,7 +46,7 @@ exports[`renders correctly 1`] = `
 
 .c4 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c5 {
@@ -71,7 +71,7 @@ exports[`renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;

--- a/src/components/Molecules/Typeahead/__snapshots__/Typeahead.test.js.snap
+++ b/src/components/Molecules/Typeahead/__snapshots__/Typeahead.test.js.snap
@@ -139,8 +139,8 @@ exports[`renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c4 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/src/components/Molecules/Typeahead/__snapshots__/Typeahead.test.js.snap
+++ b/src/components/Molecules/Typeahead/__snapshots__/Typeahead.test.js.snap
@@ -46,7 +46,15 @@ exports[`renders correctly 1`] = `
 
 .c4 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c5 {
@@ -119,6 +127,20 @@ exports[`renders correctly 1`] = `
   .c3 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c4 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c4 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 

--- a/src/components/Organisms/Donate/__snapshots__/Donate.test.js.snap
+++ b/src/components/Organisms/Donate/__snapshots__/Donate.test.js.snap
@@ -568,8 +568,8 @@ exports[`"Single Giving, No Money Buys, with overridden manual input value" rend
 
 @media (min-width:1024px) {
   .c22 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -1394,8 +1394,8 @@ exports[`Monthly donation renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c23 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -2206,8 +2206,8 @@ exports[`Single donation renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c16 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -2994,8 +2994,8 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c16 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/src/components/Organisms/Donate/__snapshots__/Donate.test.js.snap
+++ b/src/components/Organisms/Donate/__snapshots__/Donate.test.js.snap
@@ -117,7 +117,7 @@ exports[`"Single Giving, No Money Buys, with overridden manual input value" rend
 
 .c22 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c23 {
@@ -142,7 +142,7 @@ exports[`"Single Giving, No Money Buys, with overridden manual input value" rend
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -942,7 +942,7 @@ exports[`Monthly donation renders correctly 1`] = `
 
 .c23 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c24 {
@@ -967,7 +967,7 @@ exports[`Monthly donation renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -1746,7 +1746,7 @@ exports[`Single donation renders correctly 1`] = `
 
 .c16 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c17 {
@@ -1771,7 +1771,7 @@ exports[`Single donation renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -2616,7 +2616,7 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
 
 .c16 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c17 {
@@ -2641,7 +2641,7 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;

--- a/src/components/Organisms/Donate/__snapshots__/Donate.test.js.snap
+++ b/src/components/Organisms/Donate/__snapshots__/Donate.test.js.snap
@@ -117,7 +117,15 @@ exports[`"Single Giving, No Money Buys, with overridden manual input value" rend
 
 .c22 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c23 {
@@ -552,6 +560,20 @@ exports[`"Single Giving, No Money Buys, with overridden manual input value" rend
 }
 
 @media (min-width:740px) {
+  .c22 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c22 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:740px) {
 
 }
 
@@ -942,7 +964,15 @@ exports[`Monthly donation renders correctly 1`] = `
 
 .c23 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c24 {
@@ -1356,6 +1386,20 @@ exports[`Monthly donation renders correctly 1`] = `
 }
 
 @media (min-width:740px) {
+  .c23 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c23 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:740px) {
 
 }
 
@@ -1746,7 +1790,15 @@ exports[`Single donation renders correctly 1`] = `
 
 .c16 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c17 {
@@ -2142,6 +2194,20 @@ exports[`Single donation renders correctly 1`] = `
   .c15 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c16 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -2616,7 +2682,15 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
 
 .c16 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c17 {
@@ -2908,6 +2982,20 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
   .c15 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c16 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 

--- a/src/components/Organisms/DonateBanner/__snapshots__/DonateBanner.test.js.snap
+++ b/src/components/Organisms/DonateBanner/__snapshots__/DonateBanner.test.js.snap
@@ -72,7 +72,7 @@ exports[`Monthly donation renders correctly 1`] = `
 
 .c21 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c23 {
@@ -97,7 +97,7 @@ exports[`Monthly donation renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   padding-left: calc(1.5rem + (1 * 0.5rem));
   background-color: #F4F3F5;
   border: 1px solid;
@@ -875,7 +875,7 @@ exports[`Single donation renders correctly 1`] = `
 
 .c14 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c15 {
@@ -900,7 +900,7 @@ exports[`Single donation renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   padding-left: calc(1.5rem + (1 * 0.5rem));
   background-color: #F4F3F5;
   border: 1px solid;
@@ -925,7 +925,7 @@ exports[`Single donation renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -1766,7 +1766,7 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
 
 .c16 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c18 {
@@ -1791,7 +1791,7 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   padding-left: calc(1.5rem + (1 * 0.5rem));
   background-color: #F4F3F5;
   border: 1px solid;
@@ -2368,7 +2368,7 @@ exports[`Text-only donate widget renders correctly 1`] = `
 
 .c23 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c25 {
@@ -2393,7 +2393,7 @@ exports[`Text-only donate widget renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   padding-left: calc(1.5rem + (1 * 0.5rem));
   background-color: #F4F3F5;
   border: 1px solid;

--- a/src/components/Organisms/DonateBanner/__snapshots__/DonateBanner.test.js.snap
+++ b/src/components/Organisms/DonateBanner/__snapshots__/DonateBanner.test.js.snap
@@ -72,7 +72,15 @@ exports[`Monthly donation renders correctly 1`] = `
 
 .c21 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c23 {
@@ -508,6 +516,20 @@ exports[`Monthly donation renders correctly 1`] = `
 }
 
 @media (min-width:740px) {
+  .c21 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c21 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:740px) {
 
 }
 
@@ -875,7 +897,15 @@ exports[`Single donation renders correctly 1`] = `
 
 .c14 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c15 {
@@ -1282,6 +1312,20 @@ exports[`Single donation renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c19 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c14 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c14 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
@@ -1766,7 +1810,15 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
 
 .c16 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c18 {
@@ -2064,6 +2116,20 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c11 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c16 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }
@@ -2368,7 +2434,15 @@ exports[`Text-only donate widget renders correctly 1`] = `
 
 .c23 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c25 {
@@ -2874,6 +2948,20 @@ exports[`Text-only donate widget renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c18 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c23 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c23 {
     font-size: 1.125rem;
     line-height: 1.375rem;
   }

--- a/src/components/Organisms/DonateBanner/__snapshots__/DonateBanner.test.js.snap
+++ b/src/components/Organisms/DonateBanner/__snapshots__/DonateBanner.test.js.snap
@@ -524,8 +524,8 @@ exports[`Monthly donation renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c21 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -1326,8 +1326,8 @@ exports[`Single donation renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c14 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -2130,8 +2130,8 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c16 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -2962,8 +2962,8 @@ exports[`Text-only donate widget renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c23 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/src/components/Organisms/EmailBanner/__snapshots__/EmailBanner.test.js.snap
+++ b/src/components/Organisms/EmailBanner/__snapshots__/EmailBanner.test.js.snap
@@ -122,7 +122,7 @@ exports[`Image banner left orientation renders correctly 1`] = `
 
 .c16 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c17 {
@@ -147,7 +147,7 @@ exports[`Image banner left orientation renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -863,7 +863,7 @@ exports[`Image banner renders correctly 1`] = `
 
 .c16 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c17 {
@@ -888,7 +888,7 @@ exports[`Image banner renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -1604,7 +1604,7 @@ exports[`Text-only email widget renders correctly 1`] = `
 
 .c16 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c17 {
@@ -1629,7 +1629,7 @@ exports[`Text-only email widget renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -2345,7 +2345,7 @@ exports[`Text-only email widget with copyColor renders correctly 1`] = `
 
 .c16 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c17 {
@@ -2370,7 +2370,7 @@ exports[`Text-only email widget with copyColor renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;

--- a/src/components/Organisms/EmailBanner/__snapshots__/EmailBanner.test.js.snap
+++ b/src/components/Organisms/EmailBanner/__snapshots__/EmailBanner.test.js.snap
@@ -122,7 +122,15 @@ exports[`Image banner left orientation renders correctly 1`] = `
 
 .c16 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c17 {
@@ -411,6 +419,20 @@ exports[`Image banner left orientation renders correctly 1`] = `
   .c15 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c16 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -863,7 +885,15 @@ exports[`Image banner renders correctly 1`] = `
 
 .c16 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c17 {
@@ -1152,6 +1182,20 @@ exports[`Image banner renders correctly 1`] = `
   .c15 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c16 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -1604,7 +1648,15 @@ exports[`Text-only email widget renders correctly 1`] = `
 
 .c16 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c17 {
@@ -1893,6 +1945,20 @@ exports[`Text-only email widget renders correctly 1`] = `
   .c15 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c16 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -2345,7 +2411,15 @@ exports[`Text-only email widget with copyColor renders correctly 1`] = `
 
 .c16 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c17 {
@@ -2634,6 +2708,20 @@ exports[`Text-only email widget with copyColor renders correctly 1`] = `
   .c15 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c16 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c16 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 

--- a/src/components/Organisms/EmailBanner/__snapshots__/EmailBanner.test.js.snap
+++ b/src/components/Organisms/EmailBanner/__snapshots__/EmailBanner.test.js.snap
@@ -431,8 +431,8 @@ exports[`Image banner left orientation renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c16 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -1194,8 +1194,8 @@ exports[`Image banner renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c16 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -1957,8 +1957,8 @@ exports[`Text-only email widget renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c16 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -2720,8 +2720,8 @@ exports[`Text-only email widget with copyColor renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c16 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -125,7 +125,7 @@ exports[`renders correctly 1`] = `
 
 .c11 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c12 {
@@ -150,7 +150,7 @@ exports[`renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -125,7 +125,15 @@ exports[`renders correctly 1`] = `
 
 .c11 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c12 {
@@ -329,6 +337,20 @@ exports[`renders correctly 1`] = `
   .c10 {
     font-size: 1rem;
     line-height: 1.25rem;
+  }
+}
+
+@media (min-width:740px) {
+  .c11 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c11 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 

--- a/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
+++ b/src/components/Organisms/EmailSignUp/__snapshots__/EmailSignUp.test.js.snap
@@ -349,8 +349,8 @@ exports[`renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c11 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/src/components/Organisms/FooterNew/__snapshots__/FooterNew.test.js.snap
+++ b/src/components/Organisms/FooterNew/__snapshots__/FooterNew.test.js.snap
@@ -857,8 +857,8 @@ exports[`does not render copyright text when not supplied 1`] = `
 
 @media (min-width:1024px) {
   .c19 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 
@@ -2503,8 +2503,8 @@ exports[`renders correctly 1`] = `
 
 @media (min-width:1024px) {
   .c19 {
-    font-size: 1.125rem;
-    line-height: 1.375rem;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
   }
 }
 

--- a/src/components/Organisms/FooterNew/__snapshots__/FooterNew.test.js.snap
+++ b/src/components/Organisms/FooterNew/__snapshots__/FooterNew.test.js.snap
@@ -154,7 +154,15 @@ exports[`does not render copyright text when not supplied 1`] = `
 
 .c19 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c20 {
@@ -837,6 +845,20 @@ exports[`does not render copyright text when not supplied 1`] = `
 @media (min-width:1024px) {
   .c23 {
     width: auto;
+  }
+}
+
+@media (min-width:740px) {
+  .c19 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c19 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 
@@ -1778,7 +1800,15 @@ exports[`renders correctly 1`] = `
 
 .c19 {
   position: relative;
+  font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+  font-weight: 400;
+  text-transform: inherit;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
   font-size: 1rem;
+  line-height: 1.25rem;
 }
 
 .c20 {
@@ -2461,6 +2491,20 @@ exports[`renders correctly 1`] = `
 @media (min-width:1024px) {
   .c23 {
     width: auto;
+  }
+}
+
+@media (min-width:740px) {
+  .c19 {
+    font-size: 1rem;
+    line-height: 1.25rem;
+  }
+}
+
+@media (min-width:1024px) {
+  .c19 {
+    font-size: 1.125rem;
+    line-height: 1.375rem;
   }
 }
 

--- a/src/components/Organisms/FooterNew/__snapshots__/FooterNew.test.js.snap
+++ b/src/components/Organisms/FooterNew/__snapshots__/FooterNew.test.js.snap
@@ -154,7 +154,7 @@ exports[`does not render copyright text when not supplied 1`] = `
 
 .c19 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c20 {
@@ -179,7 +179,7 @@ exports[`does not render copyright text when not supplied 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;
@@ -1778,7 +1778,7 @@ exports[`renders correctly 1`] = `
 
 .c19 {
   position: relative;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .c20 {
@@ -1803,7 +1803,7 @@ exports[`renders correctly 1`] = `
   box-sizing: border-box;
   width: 100%;
   height: 48px;
-  padding: 1rem 2.4rem 1rem 1.5rem;
+  padding: 1rem;
   background-color: #F4F3F5;
   border: 1px solid;
   border-color: #969598;

--- a/src/components/Organisms/Membership/Membership.test.js
+++ b/src/components/Organisms/Membership/Membership.test.js
@@ -174,7 +174,7 @@ it('renders correctly', () => {
 
     .c18 {
       position: relative;
-      font-size: 1.25rem;
+      font-size: 1rem;
     }
 
     .c19 {
@@ -199,7 +199,7 @@ it('renders correctly', () => {
       box-sizing: border-box;
       width: 100%;
       height: 48px;
-      padding: 1rem 2.4rem 1rem 1.5rem;
+      padding: 1rem;
       background-color: #F4F3F5;
       border: 1px solid;
       border-color: #969598;

--- a/src/components/Organisms/Membership/Membership.test.js
+++ b/src/components/Organisms/Membership/Membership.test.js
@@ -523,8 +523,8 @@ it('renders correctly', () => {
 
     @media (min-width:1024px) {
       .c18 {
-        font-size: 1.125rem;
-        line-height: 1.375rem;
+        font-size: 1.25rem;
+        line-height: 1.25rem;
       }
     }
 

--- a/src/components/Organisms/Membership/Membership.test.js
+++ b/src/components/Organisms/Membership/Membership.test.js
@@ -174,7 +174,15 @@ it('renders correctly', () => {
 
     .c18 {
       position: relative;
+      font-family: 'Montserrat',Helvetica,Arial,sans-serif;
+      font-weight: 400;
+      text-transform: inherit;
+      -webkit-letter-spacing: 0;
+      -moz-letter-spacing: 0;
+      -ms-letter-spacing: 0;
+      letter-spacing: 0;
       font-size: 1rem;
+      line-height: 1.25rem;
     }
 
     .c19 {
@@ -503,6 +511,20 @@ it('renders correctly', () => {
       .c17 {
         font-size: 1rem;
         line-height: 1.25rem;
+      }
+    }
+
+    @media (min-width:740px) {
+      .c18 {
+        font-size: 1rem;
+        line-height: 1.25rem;
+      }
+    }
+
+    @media (min-width:1024px) {
+      .c18 {
+        font-size: 1.125rem;
+        line-height: 1.375rem;
       }
     }
 

--- a/src/theme/crTheme/fontConfig.js
+++ b/src/theme/crTheme/fontConfig.js
@@ -178,11 +178,11 @@ export default {
     weight: 400,
     transform: 'inherit',
     small: {
-      fontSize: '1.25rem',
+      fontSize: '1rem',
       lineHeight: '1.25rem'
     },
     medium: {
-      fontSize: '1.25rem',
+      fontSize: '1rem',
       lineHeight: '1.25rem'
     },
     large: {


### PR DESCRIPTION
### PR description
#### What is it doing?
Reduces our Input fields' font size from 1.25rem to 1rem, and reduces its padding to a consistent 1rem all the way around.

#### Why is this required?
Design review following the bug ticket below highlighting truncated text.

#### link to Jira ticket:
[ENG-5018]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5018]: https://comicrelief.atlassian.net/browse/ENG-5018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ