### PR TITLE
fix: Reverses arrow direction to be correct

### DIFF
--- a/src/components/Atoms/Icons/Arrow.js
+++ b/src/components/Atoms/Icons/Arrow.js
@@ -5,8 +5,8 @@ import styled, { withTheme } from 'styled-components';
 const angle = {
   right: '0',
   left: '180deg',
-  down: '-90deg',
-  up: '90deg'
+  down: '90deg',
+  up: '-90deg'
 };
 
 const Icon = styled.svg`


### PR DESCRIPTION
### PR description
#### What is it doing?
We seem to have gotten the orientation wrong of the <Arrow> component.
It's only used in one place in the frontend, on the prize page. It's highlighted that the left and right orientations are correct, but up and down are the wrong way round. This flips them so they're correct now.

#### Why is this required?
Bugfix

#### link to Jira ticket:
[ENG-5190]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5190]: https://comicrelief.atlassian.net/browse/ENG-5190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ