### PR TITLE
fix: Amend styling of CTA part of Article Teaser

### DIFF
--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.style.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.style.js
@@ -36,12 +36,15 @@ const CtaWrapper = styled.div`
   height: auto;
   position: relative;
   margin-top: auto;
-  padding: 2rem 2.5rem 0 0;
+  padding: 2rem 0 0 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: row;
 
   ${CtaIconWrapper} {
     transform: none;
     top: auto;
-    bottom: -8px;
   }
 
   span {

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -210,7 +210,22 @@ it('renders article teaser correctly', () => {
       height: auto;
       position: relative;
       margin-top: auto;
-      padding: 2rem 2.5rem 0 0;
+      padding: 2rem 0 0 0;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+      justify-content: space-between;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
     }
 
     .c16 .c21 {
@@ -218,7 +233,6 @@ it('renders article teaser correctly', () => {
       -ms-transform: none;
       transform: none;
       top: auto;
-      bottom: -8px;
     }
 
     .c16 span {
@@ -746,7 +760,22 @@ it('renders press realese correctly', () => {
       height: auto;
       position: relative;
       margin-top: auto;
-      padding: 2rem 2.5rem 0 0;
+      padding: 2rem 0 0 0;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: justify;
+      -webkit-justify-content: space-between;
+      -ms-flex-pack: justify;
+      justify-content: space-between;
+      -webkit-align-items: center;
+      -webkit-box-align: center;
+      -ms-flex-align: center;
+      align-items: center;
+      -webkit-flex-direction: row;
+      -ms-flex-direction: row;
+      flex-direction: row;
     }
 
     .c16 .c21 {
@@ -754,7 +783,6 @@ it('renders press realese correctly', () => {
       -ms-transform: none;
       transform: none;
       top: auto;
-      bottom: -8px;
     }
 
     .c16 span {


### PR DESCRIPTION
### PR description
#### What is it doing?
Fixes a regression added by recent work on the ArticleTeaser component, where Prize cards have a CTA section that's a bit wonky.

On the right, how the prize cards currently appear, on the left is one corrected via the dev console. I've then just mirrored those necessary changes here in the CL.
<img width="733" height="456" alt="image" src="https://github.com/user-attachments/assets/e4659aaa-394a-42f0-9bed-8a4f8ac5c042" />

I've double checked this branch in the frontend and it appears OK, here's the news which also uses it:

<img width="1179" height="608" alt="image" src="https://github.com/user-attachments/assets/f68b27e6-9b84-4f83-90ac-45792bf9890a" />

and prizes:

<img width="1305" height="489" alt="image" src="https://github.com/user-attachments/assets/dcb68f28-0eb1-4374-b5ff-0356d0557cfe" />

I have also checked they look good at smaller breakpoints.

#### Why is this required?
Bugfix

#### link to Jira ticket:
[ENG-5191]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5191]: https://comicrelief.atlassian.net/browse/ENG-5191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ