### PR TITLE
fix: Monthly 'other amount' text fix for Donate Banner

### DIFF
--- a/src/components/Organisms/DonateBanner/DonateBanner.js
+++ b/src/components/Organisms/DonateBanner/DonateBanner.js
@@ -31,8 +31,6 @@ const DonateBanner = ({
   subtitle = '',
   monthlyTitle = '',
   monthlySubtitle = '',
-  chooseAmountText = null,
-  monthlyChooseAmountText = null,
   otherAmountText = 'will help us fund amazing projects in the UK and around the world.',
   monthlyOtherAmountText = '',
   hideMoneyBuys = false,
@@ -141,14 +139,12 @@ const DonateBanner = ({
 
           <Form
             data={data}
-            otherAmountText={thisOtherAmountText}
             cartID={cartID}
             clientID={clientID}
             mbshipID={mbshipID}
             donateLink={donateLink}
             hideMoneyBuys={hideMoneyBuys}
-            chooseAmountText={chooseAmountText}
-            monthlyChooseAmountText={monthlyChooseAmountText}
+            otherAmountText={thisOtherAmountText}
             donateWidgetIsTextOnly={donateWidgetIsTextOnly}
             hasTopImage={shouldRenderTopImage}
             shouldShowTitleSection={shouldShowTitleSection}
@@ -178,8 +174,6 @@ DonateBanner.propTypes = {
   subtitle: PropTypes.string,
   monthlyTitle: PropTypes.string,
   monthlySubtitle: PropTypes.string,
-  chooseAmountText: PropTypes.string,
-  monthlyChooseAmountText: PropTypes.string,
   otherAmountText: PropTypes.string,
   monthlyOtherAmountText: PropTypes.string,
   hideMoneyBuys: PropTypes.bool,

--- a/src/components/Organisms/DonateBanner/DonateBanner.md
+++ b/src/components/Organisms/DonateBanner/DonateBanner.md
@@ -43,7 +43,7 @@ const imageS = {
 />;
 ```
 
-## Image banner (widget left), monthly title/subtitle + choose amount text overrides, hidden moneybuys
+## Image banner (widget left), monthly title/subtitle + amount text overrides, hidden moneybuys
 
 ```js
 import data from './dev-data/data';
@@ -85,8 +85,8 @@ const imageS = {
   subtitle="Your support can help people facing the toughest times."
   monthlyTitle="Give monthly"
   monthlySubtitle="A regular gift helps fund long-term impact."
-  chooseAmountText="Choose a one-off amount"
-  monthlyChooseAmountText="Choose a monthly amount"
+  otherAmountText="Choose a one-off amount"
+  monthlyOtherAmountText="Choose a monthly amount"
   hideMoneyBuys
 />;
 ```
@@ -111,7 +111,7 @@ import data from './dev-data/data-single';
   cartID="default-comicrelief"
   title="Donate now"
   subtitle="Make a difference today."
-  chooseAmountText="Enter an amount to give"
+  otherAmountText ="Enter an amount to give"
   hideMoneyBuys
 />;
 ```

--- a/src/components/Organisms/DonateBanner/Form/Form.js
+++ b/src/components/Organisms/DonateBanner/Form/Form.js
@@ -255,7 +255,7 @@ const Signup = ({
           )}
           <FormFieldset>
             <Label size="s" weight="500" color="black">
-              Enter another amount
+              {otherAmountText}
             </Label>
             <AmountField
               $hideMoneyBuys={hideMoneyBuys}
@@ -313,12 +313,11 @@ Signup.propTypes = {
   cartID: PropTypes.string.isRequired,
   donateLink: PropTypes.string.isRequired,
   otherAmountText: PropTypes.string.isRequired,
+  monthlyOtherAmountText: PropTypes.string,
   mbshipID: PropTypes.string.isRequired,
   donateOrientation: PropTypes.oneOf(['left', 'right']),
   hideMoneyBuys: PropTypes.bool,
   data: PropTypes.objectOf(PropTypes.shape),
-  chooseAmountText: PropTypes.string,
-  monthlyChooseAmountText: PropTypes.string,
   submitButtonColor: PropTypes.string,
   changeGivingType: PropTypes.func.isRequired,
   givingType: PropTypes.string,

--- a/src/components/Organisms/DonateBanner/Form/Form.js
+++ b/src/components/Organisms/DonateBanner/Form/Form.js
@@ -313,7 +313,6 @@ Signup.propTypes = {
   cartID: PropTypes.string.isRequired,
   donateLink: PropTypes.string.isRequired,
   otherAmountText: PropTypes.string.isRequired,
-  monthlyOtherAmountText: PropTypes.string,
   mbshipID: PropTypes.string.isRequired,
   donateOrientation: PropTypes.oneOf(['left', 'right']),
   hideMoneyBuys: PropTypes.bool,

--- a/src/components/Organisms/DonateBanner/__snapshots__/DonateBanner.test.js.snap
+++ b/src/components/Organisms/DonateBanner/__snapshots__/DonateBanner.test.js.snap
@@ -757,7 +757,7 @@ exports[`Monthly donation renders correctly 1`] = `
               <span
                 className="c16 c17"
               >
-                Enter another amount
+                will help us fund amazing projects in the UK and around the world.
               </span>
               <label
                 className="c18 c19"
@@ -1669,7 +1669,7 @@ exports[`Single donation renders correctly 1`] = `
               <span
                 className="c19 c20"
               >
-                Enter another amount
+                will help us fund amazing projects in the UK and around the world.
               </span>
               <label
                 className="c11 c21"
@@ -2284,7 +2284,7 @@ exports[`Single donation with no Money Buys renders correctly 1`] = `
               <span
                 className="c11 c12"
               >
-                Enter another amount
+                will help us fund amazing projects in the UK and around the world.
               </span>
               <label
                 className="c13 c14"
@@ -3209,7 +3209,7 @@ exports[`Text-only donate widget renders correctly 1`] = `
               <span
                 className="c18 c19"
               >
-                Enter another amount
+                will help us fund amazing projects in the UK and around the world.
               </span>
               <label
                 className="c20 c21"


### PR DESCRIPTION
### PR description
#### What is it doing?
It was found that the label above the amount input field was never fully wired up. As part of the investigation it was found that we also have some redundant props, a hangover from the previous iteration of the Donate widget. This PR:
- Uses either the `otherAmountText` or `monthlyOtherAmountText` props to label the field
- Removes the two redundant props `chooseAmountText` and `monthlyChooseAmountText`. These used to sit above the moneybuy buttons, and we don't have that text anymore.

Once this package is available I'll do the CRcom PR to finish by removing the relevant fields from the CMS.

#### Why is this required?
Bugfix & tidyup

#### link to Jira ticket:
[ENG-5197]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5197]: https://comicrelief.atlassian.net/browse/ENG-5197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ