### PR TITLE
fix: vite config tweaks for CL rebuild

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -17,10 +17,11 @@ export default defineConfig({
         return transformWithEsbuild(code, id, {
           loader: 'jsx',
           jsx: 'automatic',
+          jsxImportSource: 'react',
         });
       },
     },
-    react({ include: /\.(jsx|js)$/ }),
+    react({ jsxImportSource: 'react', include: /\.(jsx|js)$/ }),
   ],
   build: {
     lib: {
@@ -30,11 +31,13 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`,
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'styled-components'],
+      external: ['react', 'react-dom', 'react/jsx-runtime', 'react-is', 'styled-components'],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
+          'react/jsx-runtime': 'React.jsx',
+          'react-is': 'ReactIs',
           'styled-components': 'styled',
         },
       },
@@ -45,6 +48,7 @@ export default defineConfig({
       loader: {
         '.js': 'jsx',
       },
+      jsxImportSource: 'react',
     },
   },
 });


### PR DESCRIPTION
### PR description
#### What is it doing?
Tell us what it is doing from a technical perspective.
Adjust Vite config for error fixing in the CL rebuild => import into CR.com
- Old React v16 code from `react-is` was being bundled instead of externalized.
- JSX runtime wasn't explicitly configured for proper import source.

#### Why is this required?
New Vite powered CL not playing nicely when imported into CR.com

```
 ERROR  UNKNOWN

Truncated page data information for the failed page "/news/page-10/": {
  "errors": {},
  "path": "/news/page-10/",
  "slicesMap": {},
  "pageContext": {
    "limit": 21,
    "skip": 189
  }
}

failed Building static HTML for pages - 0.497s

 ERROR #95313  HTML.COMPILATION

Building static HTML failed for path "/news/page-10/"

See our docs page for more info on this error: https://gatsby.dev/debug-html


  611 |   if (wm) return Us;
  612 |   wm = 1;
> 613 |   var e = xe, t = Symbol.for("react.element"), r = Symbol.for("react.fragment"), n = Object.prototype.hasOwnProperty, i =
e.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner, s = { key: !0, ref: !0, __self: !0, __source: !0 };
      |             ^
  614 |   function l(c, p, g) {
  615 |     var h, m = {}, b = null, x = null;
  616 |     g !== void 0 && (b = "" + g), p.key !== void 0 && (b = "" + p.key), p.ref !== void 0 && (x = p.ref);


  WebpackError: TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
```



#### link to Jira ticket:
https://comicrelief.atlassian.net/browse/ENG-5217


### Quick Checklist:
- [ ] My PR title follows the Conventional Commit spec.

- [ ] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
