### PR TITLE
fix: Import fonts more efficiently

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ $ yarn add @comicrelief/component-library
 import { ThemeProvider, crTheme } from '@comicrelief/component-library';
 ```
 
+#### Load fonts in your app's HTML
+We use Anton and Montserrat fonts. Add these to your frontend's `index.html` `<head>`:
+
+```
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Anton&family=Montserrat:wght@400;500;600;700&display=swap"
+/>
+```
+
 #### Import components
 ```
 import { HeroBanner } from '@comicrelief/component-library';

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Component Library</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Montserrat:wght@400;500;600;700&display=swap"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/docs/InstallationDoc.jsx
+++ b/src/docs/InstallationDoc.jsx
@@ -15,6 +15,9 @@ export default function InstallationDoc() {
       <h4>Wrap your app with the ThemeProvider and crTheme</h4>
       <p><code style={code}>{'import { ThemeProvider, crTheme } from \'@comicrelief/component-library\';'}</code></p>
 
+      <h4>Load fonts in your app&apos;s HTML</h4>
+      <p>CR-CL uses Anton and Montserrat. Add preconnect and stylesheet links to your <code style={code}>index.html</code> — see README for the URL.</p>
+
       <h4>Import components</h4>
       <p><code style={code}>{'import { HeroBanner } from \'@comicrelief/component-library\';'}</code></p>
     </div>

--- a/src/theme/shared/global.css
+++ b/src/theme/shared/global.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Anton%7CMontserrat:400,500,600,700&display=swap');
 
 @font-face {
   font-family: 'Founders-GroteskXCondensed-Bold';


### PR DESCRIPTION
### PR description
#### What is it doing?
Our frontends can have their performance scores increased, if we change the way we’re importing fonts.

Currently the Component Library[ imports our Anton and Montserrat fonts, here in the global.css file. ](https://github.com/comicrelief/component-library/blob/master/src/theme/shared/global.css#L1)

When our frontends load, for best performance we ideally want fonts brought in early doors. 
With our current way of doing things: After the frontend has loaded its initial HTML + CSS, it’s then loading the JS bundle, with includes our CL, then reading that CSS within it, then making an import. The fonts end up coming in later than we want, and Lighthouse flags this as a performance hit.

We should

a) Still allow the CL to import fonts for dev purposes, but not as part of its exported package
b) Amend the frontends to import fonts themselves, in their index.html files

This PR amends the CL to remove the `@import` (fonts) command at the root of the problem. The CL will now import the fonts itself in the same way the frontends are going to - via their own `index.html` files.

#### Why is this required?
🚤  *SPEED*

#### link to Jira ticket:
[ENG-5226]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5226]: https://comicrelief.atlassian.net/browse/ENG-5226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ