### PR TITLE
fix: Layout shift issue when accordion is opened

### DIFF
--- a/src/components/Molecules/Accordion/Accordion.js
+++ b/src/components/Molecules/Accordion/Accordion.js
@@ -70,9 +70,6 @@ const Copy = styled.div`
   visibility: none;
   transition: all 0.2s cubic-bezier(0, 0, 0.25, 0.82);
   padding: 0 ${spacing('l')};
-  @media ${({ theme }) => theme.allBreakpoints('M')} {
-    padding: 0 ${spacing('lg')};
-  }
 
   ${({ $isOpen, $contentBottomPadding }) => ($isOpen && css`
     height: auto;

--- a/src/components/Molecules/Accordion/AccordionExample.jsx
+++ b/src/components/Molecules/Accordion/AccordionExample.jsx
@@ -45,10 +45,40 @@ export default function AccordionExample() {
               I am a title with an overridden text type and weight, to 'p' 700 which is the new donate preference
             </Text>
           }
-          >
-
+        >
           <Text tag="p" size="s">lorem ipsum</Text>
         </Accordion>
+      </Wrapper>
+
+      <Wrapper>
+        <div style={{ width: '752px' }}>
+          <Accordion
+            title={
+              <Text textTag="p" weight="700">
+                I am  in a width simulating our real world use on desktop (NB because width is fixed, this is only to demonstrate desktop mode, don't use for examining mobile view)
+              </Text>
+            }
+          >
+            <Text tag="p" size="s">
+              A STAR template answer is a structured way of responding to behavioural interview questions. Here's what it stands for:
+              <br />
+              <br />
+              S - Situation: Begin by setting the scene. Describe the context or situation you were in.
+              <br />
+              <br />
+              T - Task: Next, explain the task or challenge you were faced with. What needed to be accomplished?
+              <br />
+              <br />
+              A - Action: Then, detail the actions you took to address the situation or task. What specific steps did you take, and why?
+              <br />
+              <br />
+              R - Result: Finally, discuss the results or outcomes of your actions. What happened as a result of your efforts? Try to quantify the impact if possible.
+              <br />
+              <br />
+              Using the STAR template helps you provide a clear and concise response that highlights your abilities and experiences effectively. It guides you through structuring your answer in a way that makes it easy for the interviewer to understand and evaluate your skills and competencies.
+            </Text>
+          </Accordion>
+        </div>
       </Wrapper>
     </>
   );

--- a/src/components/Molecules/Accordion/__snapshots__/Accordion.test.js.snap
+++ b/src/components/Molecules/Accordion/__snapshots__/Accordion.test.js.snap
@@ -160,12 +160,6 @@ exports[`renders correctly 1`] = `
   }
 }
 
-@media (min-width: 740px) {
-  .c8 {
-    padding: 0 3rem;
-  }
-}
-
 @keyframes k0 {
   0% {
     margin-top: 0rem;


### PR DESCRIPTION
### PR description
#### What is it doing?
Fixes a bug where, when there's a lot of text in an accordion, the layout of the text shifts during the opening animation. See the video in the attached Jira ticket.

The cause was some old CSS that is now useless, as well as being problematic.
When closed, at M breakpoint and above there is a 'lg' (3rem) lower padding on the text (even though we can't yet see the text!)
But when opened, this is then changed to 'l' (2rem). It makes this reduction at the same time as the opening animation, which results in the text visibly shifting.

Removing this CSS as it's redundant.
Also, amends an example to mimic our real world implementation where the problem was seen: it's fixed at the same width it is eventually implemented in, and has the same problematic text block currently in use on the prod site. 

#### Why is this required?
Bugfix

#### link to Jira ticket:
[ENG-5196]


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [ ] I have added tests to cover new or changed behaviour.

- [ ] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...


[ENG-5196]: https://comicrelief.atlassian.net/browse/ENG-5196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ