### PR TITLE
fix: Add test IDs for three elements within the footer

### DIFF
--- a/src/components/Organisms/Footer/Footer.js
+++ b/src/components/Organisms/Footer/Footer.js
@@ -34,7 +34,7 @@ const Footer = ({
               <SocialIcons campaign={campaignName} />
             </SocialIconWrapper>
 
-            <Brand href="/" title={`Go to ${campaign} homepage`}>
+            <Brand href="/" title={`Go to ${campaign} homepage`} data-test="footer-logo">
               <Logo sizeSm="48px" sizeMd="72px" rotate={false} campaign={campaign} />
             </Brand>
           </FooterBranding>
@@ -42,7 +42,7 @@ const Footer = ({
 
           { showFundraisingRegulatorLogo && <FundraisingRegulatorLogo /> }
 
-          <FooterCopyright>
+          <FooterCopyright data-test="footer-copyright">
             <Text tag="p" color="grey" size="s">
               {footerCopy}
             </Text>

--- a/src/components/Organisms/Footer/Footer.js
+++ b/src/components/Organisms/Footer/Footer.js
@@ -31,7 +31,7 @@ const Footer = ({
           }
           <FooterBranding>
             <SocialIconWrapper>
-              <SocialIcons campaign={campaignName} />
+              <SocialIcons campaign={campaignName} data-test="SocialIconsList" />
             </SocialIconWrapper>
 
             <Brand href="/" title={`Go to ${campaign} homepage`} data-test="footer-logo">

--- a/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
@@ -674,6 +674,7 @@ exports[`renders correctly 1`] = `
         </div>
         <a
           className="c8 c9"
+          data-test="footer-logo"
           href="/"
           target="_self"
           title="Go to Comic Relief homepage"
@@ -1220,6 +1221,7 @@ exports[`renders correctly 1`] = `
       </nav>
       <div
         className="c25"
+        data-test="footer-copyright"
       >
         <p
           className="c26"


### PR DESCRIPTION
Just adding test IDs for the benefit of Donate.
In this PR https://github.com/comicrelief/react-payments/pull/362 we've got a test failing around test IDs - there's three instances of locators using the old format that Babel would throw together such as `"Footerstyle__SocialIconWrapper"`, that we can't locate anymore. 
Using TestIDs is preferable now that we've moved away from Babel

No jira ticket.