### PR TITLE
fix: Test locators amendment followup

### DIFF
--- a/src/components/Atoms/SocialIcons/SocialIcons.js
+++ b/src/components/Atoms/SocialIcons/SocialIcons.js
@@ -79,7 +79,7 @@ const SocialIcons = ({
     : ['facebook', 'instagram', 'twitter', 'youtube'];
 
   return (
-    <StyledList $newStyle={newStyle} data-testid="SocialIconsList">
+    <StyledList $newStyle={newStyle} data-test="SocialIconsList">
       {brandsToShow
         .filter(brand => shouldShowIcon(brand))
         .map(brand => {

--- a/src/components/Atoms/SocialIcons/__snapshots__/SocialIcons.test.js.snap
+++ b/src/components/Atoms/SocialIcons/__snapshots__/SocialIcons.test.js.snap
@@ -55,7 +55,7 @@ exports[`renders correctly with Comic Relief links 1`] = `
 
 <ul
   className="c0"
-  data-testid="SocialIconsList"
+  data-test="SocialIconsList"
 >
   <li
     className="c1"
@@ -191,7 +191,7 @@ exports[`renders correctly with Red Nose Day links and self target 1`] = `
 
 <ul
   className="c0"
-  data-testid="SocialIconsList"
+  data-test="SocialIconsList"
 >
   <li
     className="c1"
@@ -327,7 +327,7 @@ exports[`renders correctly with Sport Relief links 1`] = `
 
 <ul
   className="c0"
-  data-testid="SocialIconsList"
+  data-test="SocialIconsList"
 >
   <li
     className="c1"

--- a/src/components/Organisms/Footer/Footer.js
+++ b/src/components/Organisms/Footer/Footer.js
@@ -34,7 +34,7 @@ const Footer = ({
               <SocialIcons campaign={campaignName} />
             </SocialIconWrapper>
 
-            <Brand href="/" title={`Go to ${campaign} homepage`}>
+            <Brand href="/" title={`Go to ${campaign} homepage`} data-test="footer-logo">
               <Logo sizeSm="48px" sizeMd="72px" rotate={false} campaign={campaign} />
             </Brand>
           </FooterBranding>
@@ -42,7 +42,7 @@ const Footer = ({
 
           { showFundraisingRegulatorLogo && <FundraisingRegulatorLogo /> }
 
-          <FooterCopyright>
+          <FooterCopyright data-test="footer-copyright">
             <Text tag="p" color="grey" size="s">
               {footerCopy}
             </Text>

--- a/src/components/Organisms/Footer/Footer.js
+++ b/src/components/Organisms/Footer/Footer.js
@@ -31,7 +31,7 @@ const Footer = ({
           }
           <FooterBranding>
             <SocialIconWrapper>
-              <SocialIcons campaign={campaignName} />
+              <SocialIcons campaign={campaignName} data-test="SocialIconsList" />
             </SocialIconWrapper>
 
             <Brand href="/" title={`Go to ${campaign} homepage`} data-test="footer-logo">

--- a/src/components/Organisms/Footer/Footer.js
+++ b/src/components/Organisms/Footer/Footer.js
@@ -31,7 +31,7 @@ const Footer = ({
           }
           <FooterBranding>
             <SocialIconWrapper>
-              <SocialIcons campaign={campaignName} data-test="SocialIconsList" />
+              <SocialIcons campaign={campaignName} />
             </SocialIconWrapper>
 
             <Brand href="/" title={`Go to ${campaign} homepage`} data-test="footer-logo">

--- a/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
@@ -592,7 +592,7 @@ exports[`renders correctly 1`] = `
         >
           <ul
             className="c3"
-            data-testid="SocialIconsList"
+            data-test="SocialIconsList"
           >
             <li
               className="c4"

--- a/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
+++ b/src/components/Organisms/Footer/__snapshots__/Footer.test.js.snap
@@ -674,6 +674,7 @@ exports[`renders correctly 1`] = `
         </div>
         <a
           className="c8 c9"
+          data-test="footer-logo"
           href="/"
           target="_self"
           title="Go to Comic Relief homepage"
@@ -1220,6 +1221,7 @@ exports[`renders correctly 1`] = `
       </nav>
       <div
         className="c25"
+        data-test="footer-copyright"
       >
         <p
           className="c26"

--- a/src/components/Organisms/FooterNew/__snapshots__/FooterNew.test.js.snap
+++ b/src/components/Organisms/FooterNew/__snapshots__/FooterNew.test.js.snap
@@ -984,7 +984,7 @@ exports[`does not render copyright text when not supplied 1`] = `
           >
             <ul
               className="c27"
-              data-testid="SocialIconsList"
+              data-test="SocialIconsList"
             >
               <li
                 className="c28"
@@ -1170,7 +1170,7 @@ exports[`does not render copyright text when not supplied 1`] = `
       >
         <ul
           className="c27"
-          data-testid="SocialIconsList"
+          data-test="SocialIconsList"
         >
           <li
             className="c28"
@@ -2308,7 +2308,7 @@ exports[`renders correctly 1`] = `
           >
             <ul
               className="c27"
-              data-testid="SocialIconsList"
+              data-test="SocialIconsList"
             >
               <li
                 className="c28"
@@ -2494,7 +2494,7 @@ exports[`renders correctly 1`] = `
       >
         <ul
           className="c27"
-          data-testid="SocialIconsList"
+          data-test="SocialIconsList"
         >
           <li
             className="c28"


### PR DESCRIPTION
Followup to [this PR](https://github.com/comicrelief/component-library/pull/903) where the data-test ID wasn't in quite the right place

Also I'd been using `data-testid` when I meant `data-test`