### PR TITLE
ci: Upgrade actions to latest versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
 
       - name: Restore packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -32,15 +32,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
 
       - name: Restore packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -62,15 +62,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
 
       - name: Restore packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -103,15 +103,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
 
       - name: Restore packages cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,16 +1,18 @@
 name: PR
 
-on: [pull_request]
+on: pull_request
 
 jobs:
-  # https://github.com/amannn/action-semantic-pull-request#example-config
+  # See https://github.com/amannn/action-semantic-pull-request
   check-semantic-pr:
     name: Semantic pull request
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v4.4.0
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### PR description
#### What is it doing?

Bumps the actions used in GitHub Actions workflows to their latest major version.

Release notes, for reference:

- [actions/checkout v7](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v700) (intermediate: [v6](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v600), [v5](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v500), [v4](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400))
- [actions/setup-node v7](https://github.com/actions/setup-node/releases/tag/v7.0.0) (intermediate: [v6](https://github.com/actions/setup-node/releases/tag/v6.0.0), [v5](https://github.com/actions/setup-node/releases/tag/v5.0.0), [v4](https://github.com/actions/setup-node/releases/tag/v4.0.0))
- [actions/cache v6](https://github.com/actions/cache/releases/tag/v6.0.0)  (intermediate: [v5](https://github.com/actions/cache/releases/tag/v5.0.0), [v4](https://github.com/actions/cache/releases/tag/v4.0.0))
- [amannn/action-semantic-pull-request v6](https://github.com/amannn/action-semantic-pull-request/blob/main/CHANGELOG.md#600-2025-08-13) (intermediate: [v5](https://github.com/amannn/action-semantic-pull-request/blob/main/CHANGELOG.md#500-2022-10-11))

#### Why is this required?

Ensures that we are getting the latest bugfixes and removes dependence on unmaintained runtimes. Current versions depend on Node 20, causing a deprecation warning to be displayed in GitHub Actions runs.

#### link to Jira ticket:

None

### Quick Checklist:

- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.
