### PR TITLE
ci: Run publish job on all branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,6 @@ jobs:
 
   publish:
     name: Publish package to npm
-    if: github.ref == 'refs/heads/master'
     needs: playwright
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### PR description
#### What is it doing?

Removes the `if` condition on the `publish` job, so that it runs as part of the workflow on all branches, not just `master`.

Don't worry, this is not going to lead to every work-in-progress commit being published! Semantic Release does not publish releases from non-master branches, unless explicitly configured to do so. You can see this logged in the runs on this PR:

> [10:10:38 AM] [semantic-release] › ℹ  This test run was triggered on the branch run-publish-job-on-all-branches, while semantic-release is configured to only publish from master, therefore a new version won’t be published.

#### Why is this required?

I'm working on migrating this repo to use Trusted Publishing to publish its releases to npm. It will be helpful to have the `publish` job run on feature branches so that I can check that my changes are working correctly before merging.

Additionally, I note that we do not currently have a job that runs the `build` script on PRs. The `publish` job does this, so this change also ensures that we detect build-related issues before they reach `master`.

Once this PR is merged, I will make the `publish` job a required check.

#### link to Jira ticket:

None

### Quick Checklist:

- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.