### PR TITLE
fix: ENG-5146 -  correct Hero Banner and Cards hover states

### DIFF
--- a/src/components/Atoms/LogoNav2026/LogoNav2026.test.js
+++ b/src/components/Atoms/LogoNav2026/LogoNav2026.test.js
@@ -7,118 +7,118 @@ it('renders correctly', () => {
   const tree = renderWithTheme(<LogoNav2026 rotate />).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
-    .c0 img {
-      animation: k0 0.4s ease-in-out forwards;
-      animation-name: k1;
-    }
+.c0 img {
+  animation: k0 0.35s ease-in-out forwards;
+  animation-name: k1;
+}
 
-    .c0:hover img,
-    .c0:focus img {
-      animation: k0 0.4s ease-in-out forwards;
-    }
+.c0:hover img,
+.c0:focus img {
+  animation: k0 0.35s ease-in-out forwards;
+}
 
-    .c1 {
-      display: block;
-      width: auto;
-      height: 100%;
-      max-width: 100%;
-    }
+.c1 {
+  display: block;
+  width: auto;
+  height: 100%;
+  max-width: 100%;
+}
 
-    .c2 {
-      z-index: 3;
-      width: 49px;
-      height: 32px;
-      display: block;
-    }
+.c2 {
+  z-index: 3;
+  width: 49px;
+  height: 32px;
+  display: block;
+}
 
-    .c3 {
-      z-index: 3;
-      display: none;
-    }
+.c3 {
+  z-index: 3;
+  display: none;
+}
 
-    @media (min-width: 320px) {
-      .c2 {
-        display: none;
-      }
-    }
+@media (min-width: 320px) {
+  .c2 {
+    display: none;
+  }
+}
 
-    @media (min-width: 320px) {
-      .c3 {
-        display: block;
-        width: 132px;
-        height: 20px;
-      }
-    }
+@media (min-width: 320px) {
+  .c3 {
+    display: block;
+    width: 132px;
+    height: 20px;
+  }
+}
 
-    @media (min-width: 740px) {
-      .c3 {
-        width: 162px;
-        height: 25px;
-      }
-    }
+@media (min-width: 740px) {
+  .c3 {
+    width: 162px;
+    height: 25px;
+  }
+}
 
-    @media (min-width: 1024px) {
-      .c3 {
-        width: 162px;
-        min-width: 162px;
-        height: 46px;
-      }
-    }
+@media (min-width: 1024px) {
+  .c3 {
+    width: 162px;
+    min-width: 162px;
+    height: 46px;
+  }
+}
 
-    @keyframes k0 {
-      from {
-        transform: scale3d(1,1,1);
-      }
+@keyframes k0 {
+  from {
+    transform: scale3d(1,1,1);
+  }
 
-      30% {
-        transform: scale3d(1.04,1.04,1.04);
-      }
+  30% {
+    transform: scale3d(1.04,1.04,1.04);
+  }
 
-      60% {
-        transform: scale3d(1.03,1.03,1.03);
-      }
+  60% {
+    transform: scale3d(1.03,1.03,1.03);
+  }
 
-      to {
-        transform: scale3d(1.04,1.04,1.04);
-      }
-    }
+  to {
+    transform: scale3d(1.04,1.04,1.04);
+  }
+}
 
-    @keyframes k1 {
-      from {
-        transform: scale3d(1.03,1.03,1.03);
-      }
+@keyframes k1 {
+  from {
+    transform: scale3d(1.03,1.03,1.03);
+  }
 
-      30% {
-        transform: scale3d(0.99,0.99,0.99);
-      }
+  30% {
+    transform: scale3d(0.99,0.99,0.99);
+  }
 
-      60% {
-        transform: scale3d(1.01,1.01,1.01);
-      }
+  60% {
+    transform: scale3d(1.01,1.01,1.01);
+  }
 
-      to {
-        transform: scale3d(1,1,1);
-      }
-    }
+  to {
+    transform: scale3d(1,1,1);
+  }
+}
 
-    <a
-      className="c0"
-      data-testid="LogoLink"
-      href="/"
-      title="Go to Comic Relief homepage"
-    >
-      <img
-        alt="Comic Relief logo"
-        className="c1 c2"
-        data-testid="MobileImage"
-        src="mock.asset"
-      />
-      <img
-        alt="Comic Relief logo"
-        className="c1 c3"
-        data-testid="DesktopImage"
-        src="mock.asset"
-      />
-    </a>
-  `);
+<a
+  className="c0"
+  data-testid="LogoLink"
+  href="/"
+  title="Go to Comic Relief homepage"
+>
+  <img
+    alt="Comic Relief logo"
+    className="c1 c2"
+    data-testid="MobileImage"
+    src="mock.asset"
+  />
+  <img
+    alt="Comic Relief logo"
+    className="c1 c3"
+    data-testid="DesktopImage"
+    src="mock.asset"
+  />
+</a>
+`);
 });

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.js
@@ -84,7 +84,7 @@ const ArticleTeaser = ({
                 />
               </CtaText>
               <CtaIconWrapper>
-                <ArrowIconWrapper $preventHoverColourChange>
+                <ArrowIconWrapper>
                   <ArrowIconInner>
                     <ArrowIcon />
                   </ArrowIconInner>

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.style.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.style.js
@@ -5,7 +5,7 @@ import Text from '../../Atoms/Text/Text';
 import Picture from '../../Atoms/Picture/Picture';
 import link from '../../Atoms/Link/Link';
 import { bounceUpAnimation, imageZoom } from '../../../theme/shared/animations';
-import { CtaTextUnderline, CtaIconWrapper } from '../shared/ctaText/ctaText.style';
+import { CtaTextUnderline, CtaIconWrapper, CtaText } from '../shared/ctaText/ctaText.style';
 import { ArrowIconWrapper } from '../shared/ctaArrow/CtaArrowCircle.style';
 import { breakpointValues } from '../../../theme/shared/allBreakpoints';
 
@@ -47,7 +47,7 @@ const CtaWrapper = styled.div`
     top: auto;
   }
 
-  span {
+  ${CtaText} {
     font-weight: bold;
     font-size: 1rem;
     transition: color 0.15s 0.1s;
@@ -120,7 +120,7 @@ const Link = styled(link)`
       }
 
       ${CtaWrapper} {
-        span {
+        ${CtaText} {
           color: ${({ theme }) => theme.color('red')};
         }
       }

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -122,7 +122,7 @@ it('renders article teaser correctly', () => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16);
   transform: scale(1);
   transform-origin: center;
 }
@@ -326,7 +326,7 @@ it('renders article teaser correctly', () => {
 
   .c2 .c7 img {
     transform: scale(1.02);
-    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
+    transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
   }
 
   .c2:hover .c7 img {
@@ -578,7 +578,7 @@ it('renders press realese correctly', () => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16);
   transform: scale(1);
   transform-origin: center;
 }
@@ -778,7 +778,7 @@ it('renders press realese correctly', () => {
 
   .c2 .c7 img {
     transform: scale(0.9);
-    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
+    transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
   }
 
   .c2:hover .c7 img {

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -326,7 +326,7 @@ it('renders article teaser correctly', () => {
 
   .c2 .c7 img {
     transform: scale(1.02);
-    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
   }
 
   .c2:hover .c7 img {
@@ -778,7 +778,7 @@ it('renders press realese correctly', () => {
 
   .c2 .c7 img {
     transform: scale(0.9);
-    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
   }
 
   .c2:hover .c7 img {

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -94,7 +94,7 @@ it('renders article teaser correctly', () => {
   object-fit: cover;
 }
 
-.c20 {
+.c21 {
   height: 4px;
   width: 100%;
   position: absolute;
@@ -102,9 +102,10 @@ it('renders article teaser correctly', () => {
   bottom: -5px;
   transition: opacity 0.15s 0.1s;
   opacity: 0;
+  pointer-events: none;
 }
 
-.c22 {
+.c23 {
   height: 2rem;
   position: absolute;
   top: 50%;
@@ -113,11 +114,11 @@ it('renders article teaser correctly', () => {
   content: "";
 }
 
-.c18 {
+.c19 {
   position: relative;
 }
 
-.c25 {
+.c26 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -126,7 +127,7 @@ it('renders article teaser correctly', () => {
   transform-origin: center;
 }
 
-.c24 {
+.c25 {
   width: 32px;
   height: 32px;
   border-radius: 50%;
@@ -164,12 +165,12 @@ it('renders article teaser correctly', () => {
   flex-direction: row;
 }
 
-.c16 .c21 {
+.c16 .c22 {
   transform: none;
   top: auto;
 }
 
-.c16 span {
+.c16 .c18 {
   font-weight: bold;
   font-size: 1rem;
   transition: color 0.15s 0.1s;
@@ -185,7 +186,7 @@ it('renders article teaser correctly', () => {
   width: 100%;
 }
 
-.c2 .c23 {
+.c2 .c24 {
   background-color: #E52630;
 }
 
@@ -227,7 +228,7 @@ it('renders article teaser correctly', () => {
   margin-bottom: 1rem;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   color: #FFFFFF;
   fill: currentColor;
@@ -276,7 +277,7 @@ it('renders article teaser correctly', () => {
 }
 
 @media (min-width: 1024px) {
-  .c24 {
+  .c25 {
     background: #222222;
   }
 }
@@ -294,13 +295,13 @@ it('renders article teaser correctly', () => {
 }
 
 @media (min-width: 1024px) {
-  .c16 span {
+  .c16 .c18 {
     color: #000000;
   }
 }
 
 @media (min-width: 1024px) {
-  .c2 .c23 {
+  .c2 .c24 {
     transition: background-color 0.15s 0.1s;
     background-color: #000000;
   }
@@ -332,15 +333,15 @@ it('renders article teaser correctly', () => {
     transform: scale(1.04);
   }
 
-  .c2:hover .c23 {
+  .c2:hover .c24 {
     background-color: #E52630;
   }
 
-  .c2:hover .c19 {
+  .c2:hover .c20 {
     opacity: 1;
   }
 
-  .c2:hover .c15 span {
+  .c2:hover .c15 .c18 {
     color: #E52630;
   }
 }
@@ -419,26 +420,26 @@ it('renders article teaser correctly', () => {
           className="c15 c16"
         >
           <span
-            className="c17 c18"
+            className="c17 c18 c19"
           >
             Read more
             <img
               alt="Read more"
-              className="c19 c20"
+              className="c20 c21"
               src="mock.asset"
             />
           </span>
           <div
-            className="c21 c22"
+            className="c22 c23"
           >
             <div
-              className="c23 c24"
+              className="c24 c25"
             >
               <span
-                className="c25"
+                className="c26"
               >
                 <svg
-                  className="c26"
+                  className="c27"
                   fill="none"
                   height="15"
                   viewBox="0 0 15 15"
@@ -549,7 +550,7 @@ it('renders press realese correctly', () => {
   object-fit: cover;
 }
 
-.c20 {
+.c21 {
   height: 4px;
   width: 100%;
   position: absolute;
@@ -557,9 +558,10 @@ it('renders press realese correctly', () => {
   bottom: -5px;
   transition: opacity 0.15s 0.1s;
   opacity: 0;
+  pointer-events: none;
 }
 
-.c22 {
+.c23 {
   height: 2rem;
   position: absolute;
   top: 50%;
@@ -568,11 +570,11 @@ it('renders press realese correctly', () => {
   content: "";
 }
 
-.c18 {
+.c19 {
   position: relative;
 }
 
-.c25 {
+.c26 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -581,7 +583,7 @@ it('renders press realese correctly', () => {
   transform-origin: center;
 }
 
-.c24 {
+.c25 {
   width: 32px;
   height: 32px;
   border-radius: 50%;
@@ -619,12 +621,12 @@ it('renders press realese correctly', () => {
   flex-direction: row;
 }
 
-.c16 .c21 {
+.c16 .c22 {
   transform: none;
   top: auto;
 }
 
-.c16 span {
+.c16 .c18 {
   font-weight: bold;
   font-size: 1rem;
   transition: color 0.15s 0.1s;
@@ -641,7 +643,7 @@ it('renders press realese correctly', () => {
   width: 100%;
 }
 
-.c2 .c23 {
+.c2 .c24 {
   background-color: #E52630;
 }
 
@@ -684,7 +686,7 @@ it('renders press realese correctly', () => {
   margin-bottom: 1rem;
 }
 
-.c26 {
+.c27 {
   display: inline-block;
   color: #FFFFFF;
   fill: currentColor;
@@ -733,7 +735,7 @@ it('renders press realese correctly', () => {
 }
 
 @media (min-width: 1024px) {
-  .c24 {
+  .c25 {
     background: #222222;
   }
 }
@@ -745,13 +747,13 @@ it('renders press realese correctly', () => {
 }
 
 @media (min-width: 1024px) {
-  .c16 span {
+  .c16 .c18 {
     color: #000000;
   }
 }
 
 @media (min-width: 1024px) {
-  .c2 .c23 {
+  .c2 .c24 {
     transition: background-color 0.15s 0.1s;
     background-color: #000000;
   }
@@ -783,15 +785,15 @@ it('renders press realese correctly', () => {
     transform: scale(1);
   }
 
-  .c2:hover .c23 {
+  .c2:hover .c24 {
     background-color: #E52630;
   }
 
-  .c2:hover .c19 {
+  .c2:hover .c20 {
     opacity: 1;
   }
 
-  .c2:hover .c15 span {
+  .c2:hover .c15 .c18 {
     color: #E52630;
   }
 }
@@ -846,26 +848,26 @@ it('renders press realese correctly', () => {
           className="c15 c16"
         >
           <span
-            className="c17 c18"
+            className="c17 c18 c19"
           >
             Read more
             <img
               alt="Read more"
-              className="c19 c20"
+              className="c20 c21"
               src="mock.asset"
             />
           </span>
           <div
-            className="c21 c22"
+            className="c22 c23"
           >
             <div
-              className="c23 c24"
+              className="c24 c25"
             >
               <span
-                className="c25"
+                className="c26"
               >
                 <svg
-                  className="c26"
+                  className="c27"
                   fill="none"
                   height="15"
                   viewBox="0 0 15 15"

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -326,7 +326,7 @@ it('renders article teaser correctly', () => {
 
   .c2 .c7 img {
     transform: scale(1.02);
-    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
+    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
   }
 
   .c2:hover .c7 img {
@@ -778,7 +778,7 @@ it('renders press realese correctly', () => {
 
   .c2 .c7 img {
     transform: scale(0.9);
-    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
+    transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
   }
 
   .c2:hover .c7 img {

--- a/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
+++ b/src/components/Molecules/ArticleTeaser/ArticleTeaser.test.js
@@ -275,6 +275,12 @@ it('renders article teaser correctly', () => {
   }
 }
 
+@media (min-width: 1024px) {
+  .c24 {
+    background: #222222;
+  }
+}
+
 @media (min-width: 740px) {
   .c4 {
     flex-direction: row;
@@ -723,6 +729,12 @@ it('renders press realese correctly', () => {
   .c17 {
     font-size: 1.125rem;
     line-height: 1.375rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .c24 {
+    background: #222222;
   }
 }
 

--- a/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
@@ -237,7 +237,7 @@ exports[`handles data structure correctly 1`] = `
   }
 }
 
-@media (min-width:1024px) {
+@media (min-width: 1024px) {
   .c21 {
     background: #222222;
   }
@@ -916,7 +916,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   }
 }
 
-@media (min-width:1024px) {
+@media (min-width: 1024px) {
   .c21 {
     background: #222222;
   }
@@ -1621,7 +1621,7 @@ exports[`renders carousel mode correctly 1`] = `
   }
 }
 
-@media (min-width:1024px) {
+@media (min-width: 1024px) {
   .c21 {
     background: #222222;
   }
@@ -2306,7 +2306,7 @@ exports[`renders correctly with data prop 1`] = `
   }
 }
 
-@media (min-width:1024px) {
+@media (min-width: 1024px) {
   .c21 {
     background: #222222;
   }

--- a/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
@@ -57,7 +57,7 @@ exports[`handles data structure correctly 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16);
   transform: scale(1);
   transform-origin: center;
 }
@@ -114,7 +114,7 @@ exports[`handles data structure correctly 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-  transition: color 0.4s;
+  transition: color 0.35s;
 }
 
 .c6 {
@@ -125,7 +125,7 @@ exports[`handles data structure correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -140,7 +140,7 @@ exports[`handles data structure correctly 1`] = `
 
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c26 {
@@ -151,7 +151,7 @@ exports[`handles data structure correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -297,7 +297,7 @@ exports[`handles data structure correctly 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
+    transition: transform 0.35s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c6:hover,
@@ -771,7 +771,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16);
   transform: scale(1);
   transform-origin: center;
 }
@@ -828,7 +828,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-  transition: color 0.4s;
+  transition: color 0.35s;
 }
 
 .c6 {
@@ -839,7 +839,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -854,7 +854,7 @@ exports[`renders 2 columns layout correctly 1`] = `
 
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c26 {
@@ -865,7 +865,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -1011,7 +1011,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
+    transition: transform 0.35s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c6:hover,
@@ -1511,7 +1511,7 @@ exports[`renders carousel mode correctly 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16);
   transform: scale(1);
   transform-origin: center;
 }
@@ -1568,7 +1568,7 @@ exports[`renders carousel mode correctly 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-  transition: color 0.4s;
+  transition: color 0.35s;
 }
 
 .c6 {
@@ -1579,7 +1579,7 @@ exports[`renders carousel mode correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -1594,7 +1594,7 @@ exports[`renders carousel mode correctly 1`] = `
 
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c26 {
@@ -1605,7 +1605,7 @@ exports[`renders carousel mode correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -1751,7 +1751,7 @@ exports[`renders carousel mode correctly 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
+    transition: transform 0.35s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c6:hover,
@@ -2231,7 +2231,7 @@ exports[`renders correctly with data prop 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16);
   transform: scale(1);
   transform-origin: center;
 }
@@ -2288,7 +2288,7 @@ exports[`renders correctly with data prop 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-  transition: color 0.4s;
+  transition: color 0.35s;
 }
 
 .c6 {
@@ -2299,7 +2299,7 @@ exports[`renders correctly with data prop 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -2314,7 +2314,7 @@ exports[`renders correctly with data prop 1`] = `
 
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c26 {
@@ -2325,7 +2325,7 @@ exports[`renders correctly with data prop 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -2471,7 +2471,7 @@ exports[`renders correctly with data prop 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
+    transition: transform 0.35s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c6:hover,

--- a/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
@@ -42,6 +42,17 @@ exports[`handles data structure correctly 1`] = `
   object-fit: cover;
 }
 
+.c18 {
+  height: 4px;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  bottom: -5px;
+  transition: opacity 0.15s 0.1s;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .c23 {
   display: inline-flex;
   align-items: center;
@@ -103,17 +114,6 @@ exports[`handles data structure correctly 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-}
-
-.c18 {
-  height: 4px;
-  width: 100%;
-  position: absolute;
-  left: 0;
-  bottom: -5px;
-  transition: opacity 0.15s 0.1s;
-  opacity: 0;
-  pointer-events: none;
 }
 
 .c6 {
@@ -264,6 +264,25 @@ exports[`handles data structure correctly 1`] = `
 }
 
 @media (min-width: 740px) {
+  .c6:hover {
+    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+  }
+
+  .c6:hover .c15 {
+    text-decoration: none;
+    color: #E52630;
+  }
+
+  .c6:hover .c17 {
+    opacity: 1;
+  }
+
+  .c6:hover .c20 .c22 {
+    transform: scale(1.2);
+  }
+}
+
+@media (min-width: 1024px) {
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
@@ -273,10 +292,6 @@ exports[`handles data structure correctly 1`] = `
   .c6:hover,
   .c6:focus {
     transform: translateY(-10px);
-  }
-
-  .c6:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
   }
 
   .c6:hover .c7 img {
@@ -721,6 +736,17 @@ exports[`renders 2 columns layout correctly 1`] = `
   object-fit: cover;
 }
 
+.c18 {
+  height: 4px;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  bottom: -5px;
+  transition: opacity 0.15s 0.1s;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .c23 {
   display: inline-flex;
   align-items: center;
@@ -782,17 +808,6 @@ exports[`renders 2 columns layout correctly 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-}
-
-.c18 {
-  height: 4px;
-  width: 100%;
-  position: absolute;
-  left: 0;
-  bottom: -5px;
-  transition: opacity 0.15s 0.1s;
-  opacity: 0;
-  pointer-events: none;
 }
 
 .c6 {
@@ -943,6 +958,25 @@ exports[`renders 2 columns layout correctly 1`] = `
 }
 
 @media (min-width: 740px) {
+  .c6:hover {
+    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+  }
+
+  .c6:hover .c15 {
+    text-decoration: none;
+    color: #E52630;
+  }
+
+  .c6:hover .c17 {
+    opacity: 1;
+  }
+
+  .c6:hover .c20 .c22 {
+    transform: scale(1.2);
+  }
+}
+
+@media (min-width: 1024px) {
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
@@ -952,10 +986,6 @@ exports[`renders 2 columns layout correctly 1`] = `
   .c6:hover,
   .c6:focus {
     transform: translateY(-10px);
-  }
-
-  .c6:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
   }
 
   .c6:hover .c7 img {
@@ -1426,6 +1456,17 @@ exports[`renders carousel mode correctly 1`] = `
   object-fit: cover;
 }
 
+.c18 {
+  height: 4px;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  bottom: -5px;
+  transition: opacity 0.15s 0.1s;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .c23 {
   display: inline-flex;
   align-items: center;
@@ -1487,17 +1528,6 @@ exports[`renders carousel mode correctly 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-}
-
-.c18 {
-  height: 4px;
-  width: 100%;
-  position: absolute;
-  left: 0;
-  bottom: -5px;
-  transition: opacity 0.15s 0.1s;
-  opacity: 0;
-  pointer-events: none;
 }
 
 .c6 {
@@ -1648,6 +1678,25 @@ exports[`renders carousel mode correctly 1`] = `
 }
 
 @media (min-width: 740px) {
+  .c6:hover {
+    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+  }
+
+  .c6:hover .c15 {
+    text-decoration: none;
+    color: #E52630;
+  }
+
+  .c6:hover .c17 {
+    opacity: 1;
+  }
+
+  .c6:hover .c20 .c22 {
+    transform: scale(1.2);
+  }
+}
+
+@media (min-width: 1024px) {
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
@@ -1657,10 +1706,6 @@ exports[`renders carousel mode correctly 1`] = `
   .c6:hover,
   .c6:focus {
     transform: translateY(-10px);
-  }
-
-  .c6:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
   }
 
   .c6:hover .c7 img {
@@ -2111,6 +2156,17 @@ exports[`renders correctly with data prop 1`] = `
   object-fit: cover;
 }
 
+.c18 {
+  height: 4px;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  bottom: -5px;
+  transition: opacity 0.15s 0.1s;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .c23 {
   display: inline-flex;
   align-items: center;
@@ -2172,17 +2228,6 @@ exports[`renders correctly with data prop 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-}
-
-.c18 {
-  height: 4px;
-  width: 100%;
-  position: absolute;
-  left: 0;
-  bottom: -5px;
-  transition: opacity 0.15s 0.1s;
-  opacity: 0;
-  pointer-events: none;
 }
 
 .c6 {
@@ -2333,6 +2378,25 @@ exports[`renders correctly with data prop 1`] = `
 }
 
 @media (min-width: 740px) {
+  .c6:hover {
+    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+  }
+
+  .c6:hover .c15 {
+    text-decoration: none;
+    color: #E52630;
+  }
+
+  .c6:hover .c17 {
+    opacity: 1;
+  }
+
+  .c6:hover .c20 .c22 {
+    transform: scale(1.2);
+  }
+}
+
+@media (min-width: 1024px) {
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
@@ -2342,10 +2406,6 @@ exports[`renders correctly with data prop 1`] = `
   .c6:hover,
   .c6:focus {
     transform: translateY(-10px);
-  }
-
-  .c6:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
   }
 
   .c6:hover .c7 img {

--- a/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
@@ -276,15 +276,18 @@ exports[`handles data structure correctly 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c6:hover .c15 {
+  .c6:hover .c15,
+  .c6:focus .c15 {
     color: #E52630;
   }
 
-  .c6:hover .c17 {
+  .c6:hover .c17,
+  .c6:focus .c17 {
     opacity: 1;
   }
 
-  .c6:hover .c20 .c22 {
+  .c6:hover .c20 .c22,
+  .c6:focus .c20 .c22 {
     transform: scale(1.2);
   }
 }
@@ -301,19 +304,23 @@ exports[`handles data structure correctly 1`] = `
     transform: translateY(-10px);
   }
 
-  .c6:hover .c7 img {
+  .c6:hover .c7 img,
+  .c6:focus .c7 img {
     transform: scale(1.06);
   }
 
-  .c6:hover .c15 {
+  .c6:hover .c15,
+  .c6:focus .c15 {
     color: #E52630;
   }
 
-  .c6:hover .c17 {
+  .c6:hover .c17,
+  .c6:focus .c17 {
     opacity: 1;
   }
 
-  .c6:hover .c20 .c22 {
+  .c6:hover .c20 .c22,
+  .c6:focus .c20 .c22 {
     transform: scale(1.2);
   }
 }
@@ -977,15 +984,18 @@ exports[`renders 2 columns layout correctly 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c6:hover .c15 {
+  .c6:hover .c15,
+  .c6:focus .c15 {
     color: #E52630;
   }
 
-  .c6:hover .c17 {
+  .c6:hover .c17,
+  .c6:focus .c17 {
     opacity: 1;
   }
 
-  .c6:hover .c20 .c22 {
+  .c6:hover .c20 .c22,
+  .c6:focus .c20 .c22 {
     transform: scale(1.2);
   }
 }
@@ -1002,19 +1012,23 @@ exports[`renders 2 columns layout correctly 1`] = `
     transform: translateY(-10px);
   }
 
-  .c6:hover .c7 img {
+  .c6:hover .c7 img,
+  .c6:focus .c7 img {
     transform: scale(1.06);
   }
 
-  .c6:hover .c15 {
+  .c6:hover .c15,
+  .c6:focus .c15 {
     color: #E52630;
   }
 
-  .c6:hover .c17 {
+  .c6:hover .c17,
+  .c6:focus .c17 {
     opacity: 1;
   }
 
-  .c6:hover .c20 .c22 {
+  .c6:hover .c20 .c22,
+  .c6:focus .c20 .c22 {
     transform: scale(1.2);
   }
 }
@@ -1704,15 +1718,18 @@ exports[`renders carousel mode correctly 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c6:hover .c15 {
+  .c6:hover .c15,
+  .c6:focus .c15 {
     color: #E52630;
   }
 
-  .c6:hover .c17 {
+  .c6:hover .c17,
+  .c6:focus .c17 {
     opacity: 1;
   }
 
-  .c6:hover .c20 .c22 {
+  .c6:hover .c20 .c22,
+  .c6:focus .c20 .c22 {
     transform: scale(1.2);
   }
 }
@@ -1729,19 +1746,23 @@ exports[`renders carousel mode correctly 1`] = `
     transform: translateY(-10px);
   }
 
-  .c6:hover .c7 img {
+  .c6:hover .c7 img,
+  .c6:focus .c7 img {
     transform: scale(1.06);
   }
 
-  .c6:hover .c15 {
+  .c6:hover .c15,
+  .c6:focus .c15 {
     color: #E52630;
   }
 
-  .c6:hover .c17 {
+  .c6:hover .c17,
+  .c6:focus .c17 {
     opacity: 1;
   }
 
-  .c6:hover .c20 .c22 {
+  .c6:hover .c20 .c22,
+  .c6:focus .c20 .c22 {
     transform: scale(1.2);
   }
 }
@@ -2411,15 +2432,18 @@ exports[`renders correctly with data prop 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c6:hover .c15 {
+  .c6:hover .c15,
+  .c6:focus .c15 {
     color: #E52630;
   }
 
-  .c6:hover .c17 {
+  .c6:hover .c17,
+  .c6:focus .c17 {
     opacity: 1;
   }
 
-  .c6:hover .c20 .c22 {
+  .c6:hover .c20 .c22,
+  .c6:focus .c20 .c22 {
     transform: scale(1.2);
   }
 }
@@ -2436,19 +2460,23 @@ exports[`renders correctly with data prop 1`] = `
     transform: translateY(-10px);
   }
 
-  .c6:hover .c7 img {
+  .c6:hover .c7 img,
+  .c6:focus .c7 img {
     transform: scale(1.06);
   }
 
-  .c6:hover .c15 {
+  .c6:hover .c15,
+  .c6:focus .c15 {
     color: #E52630;
   }
 
-  .c6:hover .c17 {
+  .c6:hover .c17,
+  .c6:focus .c17 {
     opacity: 1;
   }
 
-  .c6:hover .c20 .c22 {
+  .c6:hover .c20 .c22,
+  .c6:focus .c20 .c22 {
     transform: scale(1.2);
   }
 }

--- a/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
@@ -114,6 +114,7 @@ exports[`handles data structure correctly 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
+  transition: color 0.4s;
 }
 
 .c6 {
@@ -124,7 +125,7 @@ exports[`handles data structure correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -139,7 +140,7 @@ exports[`handles data structure correctly 1`] = `
 
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
 }
 
 .c26 {
@@ -150,7 +151,7 @@ exports[`handles data structure correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -296,7 +297,7 @@ exports[`handles data structure correctly 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
   }
 
   .c6:hover,
@@ -317,6 +318,11 @@ exports[`handles data structure correctly 1`] = `
   .c6:hover .c17,
   .c6:focus .c17 {
     opacity: 1;
+  }
+
+  .c6:hover .c20,
+  .c6:focus .c20 {
+    background: #E52630;
   }
 
   .c6:hover .c20 .c22,
@@ -822,6 +828,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
+  transition: color 0.4s;
 }
 
 .c6 {
@@ -832,7 +839,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -847,7 +854,7 @@ exports[`renders 2 columns layout correctly 1`] = `
 
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
 }
 
 .c26 {
@@ -858,7 +865,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -1004,7 +1011,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
   }
 
   .c6:hover,
@@ -1025,6 +1032,11 @@ exports[`renders 2 columns layout correctly 1`] = `
   .c6:hover .c17,
   .c6:focus .c17 {
     opacity: 1;
+  }
+
+  .c6:hover .c20,
+  .c6:focus .c20 {
+    background: #E52630;
   }
 
   .c6:hover .c20 .c22,
@@ -1556,6 +1568,7 @@ exports[`renders carousel mode correctly 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
+  transition: color 0.4s;
 }
 
 .c6 {
@@ -1566,7 +1579,7 @@ exports[`renders carousel mode correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -1581,7 +1594,7 @@ exports[`renders carousel mode correctly 1`] = `
 
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
 }
 
 .c26 {
@@ -1592,7 +1605,7 @@ exports[`renders carousel mode correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -1738,7 +1751,7 @@ exports[`renders carousel mode correctly 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
   }
 
   .c6:hover,
@@ -1759,6 +1772,11 @@ exports[`renders carousel mode correctly 1`] = `
   .c6:hover .c17,
   .c6:focus .c17 {
     opacity: 1;
+  }
+
+  .c6:hover .c20,
+  .c6:focus .c20 {
+    background: #E52630;
   }
 
   .c6:hover .c20 .c22,
@@ -2270,6 +2288,7 @@ exports[`renders correctly with data prop 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
+  transition: color 0.4s;
 }
 
 .c6 {
@@ -2280,7 +2299,7 @@ exports[`renders correctly with data prop 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -2295,7 +2314,7 @@ exports[`renders correctly with data prop 1`] = `
 
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
 }
 
 .c26 {
@@ -2306,7 +2325,7 @@ exports[`renders correctly with data prop 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -2452,7 +2471,7 @@ exports[`renders correctly with data prop 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
   }
 
   .c6:hover,
@@ -2473,6 +2492,11 @@ exports[`renders correctly with data prop 1`] = `
   .c6:hover .c17,
   .c6:focus .c17 {
     opacity: 1;
+  }
+
+  .c6:hover .c20,
+  .c6:focus .c20 {
+    background: #E52630;
   }
 
   .c6:hover .c20 .c22,

--- a/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
@@ -124,6 +124,7 @@ exports[`handles data structure correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -131,9 +132,14 @@ exports[`handles data structure correctly 1`] = `
   box-sizing: border-box;
 }
 
+.c6:hover,
+.c6:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+}
+
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c26 {
@@ -144,11 +150,17 @@ exports[`handles data structure correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
   cursor: default;
   box-sizing: border-box;
+}
+
+.c26:hover,
+.c26:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
 }
 
 .c4 {
@@ -264,12 +276,7 @@ exports[`handles data structure correctly 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c6:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
-  }
-
   .c6:hover .c15 {
-    text-decoration: none;
     color: #E52630;
   }
 
@@ -286,7 +293,7 @@ exports[`handles data structure correctly 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c6:hover,
@@ -299,7 +306,7 @@ exports[`handles data structure correctly 1`] = `
   }
 
   .c6:hover .c15 {
-    text-decoration: none;
+    color: #E52630;
   }
 
   .c6:hover .c17 {
@@ -818,6 +825,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -825,9 +833,14 @@ exports[`renders 2 columns layout correctly 1`] = `
   box-sizing: border-box;
 }
 
+.c6:hover,
+.c6:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+}
+
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c26 {
@@ -838,11 +851,17 @@ exports[`renders 2 columns layout correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
   cursor: default;
   box-sizing: border-box;
+}
+
+.c26:hover,
+.c26:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
 }
 
 .c4 {
@@ -958,12 +977,7 @@ exports[`renders 2 columns layout correctly 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c6:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
-  }
-
   .c6:hover .c15 {
-    text-decoration: none;
     color: #E52630;
   }
 
@@ -980,7 +994,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c6:hover,
@@ -993,7 +1007,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   }
 
   .c6:hover .c15 {
-    text-decoration: none;
+    color: #E52630;
   }
 
   .c6:hover .c17 {
@@ -1538,6 +1552,7 @@ exports[`renders carousel mode correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -1545,9 +1560,14 @@ exports[`renders carousel mode correctly 1`] = `
   box-sizing: border-box;
 }
 
+.c6:hover,
+.c6:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+}
+
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c26 {
@@ -1558,11 +1578,17 @@ exports[`renders carousel mode correctly 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
   cursor: default;
   box-sizing: border-box;
+}
+
+.c26:hover,
+.c26:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
 }
 
 .c4 {
@@ -1678,12 +1704,7 @@ exports[`renders carousel mode correctly 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c6:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
-  }
-
   .c6:hover .c15 {
-    text-decoration: none;
     color: #E52630;
   }
 
@@ -1700,7 +1721,7 @@ exports[`renders carousel mode correctly 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c6:hover,
@@ -1713,7 +1734,7 @@ exports[`renders carousel mode correctly 1`] = `
   }
 
   .c6:hover .c15 {
-    text-decoration: none;
+    color: #E52630;
   }
 
   .c6:hover .c17 {
@@ -2238,6 +2259,7 @@ exports[`renders correctly with data prop 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -2245,9 +2267,14 @@ exports[`renders correctly with data prop 1`] = `
   box-sizing: border-box;
 }
 
+.c6:hover,
+.c6:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+}
+
 .c6 .c7 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c26 {
@@ -2258,11 +2285,17 @@ exports[`renders correctly with data prop 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
   cursor: default;
   box-sizing: border-box;
+}
+
+.c26:hover,
+.c26:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
 }
 
 .c4 {
@@ -2378,12 +2411,7 @@ exports[`renders correctly with data prop 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c6:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
-  }
-
   .c6:hover .c15 {
-    text-decoration: none;
     color: #E52630;
   }
 
@@ -2400,7 +2428,7 @@ exports[`renders correctly with data prop 1`] = `
   .c6 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c6:hover,
@@ -2413,7 +2441,7 @@ exports[`renders correctly with data prop 1`] = `
   }
 
   .c6:hover .c15 {
-    text-decoration: none;
+    color: #E52630;
   }
 
   .c6:hover .c17 {

--- a/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTAMultiCard/__snapshots__/CTAMultiCard.test.js.snap
@@ -131,7 +131,7 @@ exports[`handles data structure correctly 1`] = `
   box-sizing: border-box;
 }
 
-.c6 img {
+.c6 .c7 img {
   transform: scale(1);
   transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
 }
@@ -825,7 +825,7 @@ exports[`renders 2 columns layout correctly 1`] = `
   box-sizing: border-box;
 }
 
-.c6 img {
+.c6 .c7 img {
   transform: scale(1);
   transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
 }
@@ -1545,7 +1545,7 @@ exports[`renders carousel mode correctly 1`] = `
   box-sizing: border-box;
 }
 
-.c6 img {
+.c6 .c7 img {
   transform: scale(1);
   transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
 }
@@ -2245,7 +2245,7 @@ exports[`renders correctly with data prop 1`] = `
   box-sizing: border-box;
 }
 
-.c6 img {
+.c6 .c7 img {
   transform: scale(1);
   transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
 }

--- a/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
@@ -42,6 +42,17 @@ exports[`renders correctly with data prop 1`] = `
   object-fit: cover;
 }
 
+.c17 {
+  height: 4px;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  bottom: -5px;
+  transition: opacity 0.15s 0.1s;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .c22 {
   display: inline-flex;
   align-items: center;
@@ -103,17 +114,6 @@ exports[`renders correctly with data prop 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-}
-
-.c17 {
-  height: 4px;
-  width: 100%;
-  position: absolute;
-  left: 0;
-  bottom: -5px;
-  transition: opacity 0.15s 0.1s;
-  opacity: 0;
-  pointer-events: none;
 }
 
 .c4 {
@@ -285,6 +285,25 @@ exports[`renders correctly with data prop 1`] = `
 }
 
 @media (min-width: 740px) {
+  .c4:hover {
+    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+  }
+
+  .c4:hover .c14 {
+    text-decoration: none;
+    color: #E52630;
+  }
+
+  .c4:hover .c16 {
+    opacity: 1;
+  }
+
+  .c4:hover .c19 .c21 {
+    transform: scale(1.2);
+  }
+}
+
+@media (min-width: 1024px) {
   .c4 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
@@ -294,10 +313,6 @@ exports[`renders correctly with data prop 1`] = `
   .c4:hover,
   .c4:focus {
     transform: translateY(-10px);
-  }
-
-  .c4:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
   }
 
   .c4:hover .c5 img {
@@ -501,6 +516,17 @@ exports[`renders correctly without image 1`] = `
   text-decoration: none;
 }
 
+.c13 {
+  height: 4px;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  bottom: -5px;
+  transition: opacity 0.15s 0.1s;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .c18 {
   display: inline-flex;
   align-items: center;
@@ -547,17 +573,6 @@ exports[`renders correctly without image 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-}
-
-.c13 {
-  height: 4px;
-  width: 100%;
-  position: absolute;
-  left: 0;
-  bottom: -5px;
-  transition: opacity 0.15s 0.1s;
-  opacity: 0;
-  pointer-events: none;
 }
 
 .c4 {
@@ -696,6 +711,25 @@ exports[`renders correctly without image 1`] = `
 }
 
 @media (min-width: 740px) {
+  .c4:hover {
+    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+  }
+
+  .c4:hover .c10 {
+    text-decoration: none;
+    color: #E52630;
+  }
+
+  .c4:hover .c12 {
+    opacity: 1;
+  }
+
+  .c4:hover .c15 .c17 {
+    transform: scale(1.2);
+  }
+}
+
+@media (min-width: 1024px) {
   .c4 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
@@ -705,10 +739,6 @@ exports[`renders correctly without image 1`] = `
   .c4:hover,
   .c4:focus {
     transform: translateY(-10px);
-  }
-
-  .c4:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
   }
 
   .c4:hover .c10 {

--- a/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
@@ -124,6 +124,7 @@ exports[`renders correctly with data prop 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -131,9 +132,14 @@ exports[`renders correctly with data prop 1`] = `
   box-sizing: border-box;
 }
 
+.c4:hover,
+.c4:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
+}
+
 .c4 .c5 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c2 {
@@ -285,12 +291,7 @@ exports[`renders correctly with data prop 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c4:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
-  }
-
   .c4:hover .c14 {
-    text-decoration: none;
     color: #E52630;
   }
 
@@ -307,7 +308,7 @@ exports[`renders correctly with data prop 1`] = `
   .c4 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c4:hover,
@@ -320,7 +321,7 @@ exports[`renders correctly with data prop 1`] = `
   }
 
   .c4:hover .c14 {
-    text-decoration: none;
+    color: #E52630;
   }
 
   .c4:hover .c16 {
@@ -583,11 +584,17 @@ exports[`renders correctly without image 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
   cursor: pointer;
   box-sizing: border-box;
+}
+
+.c4:hover,
+.c4:focus {
+  box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
 }
 
 .c2 {
@@ -706,12 +713,7 @@ exports[`renders correctly without image 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c4:hover {
-    box-shadow: rgba(0,0,0,0.25) 0px 0px 1rem;
-  }
-
   .c4:hover .c10 {
-    text-decoration: none;
     color: #E52630;
   }
 
@@ -728,7 +730,7 @@ exports[`renders correctly without image 1`] = `
   .c4 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c4:hover,
@@ -737,7 +739,7 @@ exports[`renders correctly without image 1`] = `
   }
 
   .c4:hover .c10 {
-    text-decoration: none;
+    color: #E52630;
   }
 
   .c4:hover .c12 {

--- a/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
@@ -57,7 +57,7 @@ exports[`renders correctly with data prop 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16);
   transform: scale(1);
   transform-origin: center;
 }
@@ -114,7 +114,7 @@ exports[`renders correctly with data prop 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-  transition: color 0.4s;
+  transition: color 0.35s;
 }
 
 .c4 {
@@ -125,7 +125,7 @@ exports[`renders correctly with data prop 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -140,7 +140,7 @@ exports[`renders correctly with data prop 1`] = `
 
 .c4 .c5 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
 }
 
 .c2 {
@@ -312,7 +312,7 @@ exports[`renders correctly with data prop 1`] = `
   .c4 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
+    transition: transform 0.35s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c4:hover,
@@ -545,7 +545,7 @@ exports[`renders correctly without image 1`] = `
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
+  transition: transform 0.35s cubic-bezier(0.65,-0.19,0.37,1.16);
   transform: scale(1);
   transform-origin: center;
 }
@@ -587,7 +587,7 @@ exports[`renders correctly without image 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
-  transition: color 0.4s;
+  transition: color 0.35s;
 }
 
 .c4 {
@@ -598,7 +598,7 @@ exports[`renders correctly without image 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -747,7 +747,7 @@ exports[`renders correctly without image 1`] = `
   .c4 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
+    transition: transform 0.35s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
   }
 
   .c4:hover,

--- a/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
@@ -131,7 +131,7 @@ exports[`renders correctly with data prop 1`] = `
   box-sizing: border-box;
 }
 
-.c4 img {
+.c4 .c5 img {
   transform: scale(1);
   transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
 }
@@ -588,11 +588,6 @@ exports[`renders correctly without image 1`] = `
   overflow: hidden;
   cursor: pointer;
   box-sizing: border-box;
-}
-
-.c4 img {
-  transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16);
 }
 
 .c2 {

--- a/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
@@ -211,7 +211,7 @@ exports[`renders correctly with data prop 1`] = `
   }
 }
 
-@media (min-width:1024px) {
+@media (min-width: 1024px) {
   .c20 {
     background: #222222;
   }
@@ -655,7 +655,7 @@ exports[`renders correctly without image 1`] = `
   }
 }
 
-@media (min-width:1024px) {
+@media (min-width: 1024px) {
   .c16 {
     background: #222222;
   }

--- a/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
@@ -291,15 +291,18 @@ exports[`renders correctly with data prop 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c4:hover .c14 {
+  .c4:hover .c14,
+  .c4:focus .c14 {
     color: #E52630;
   }
 
-  .c4:hover .c16 {
+  .c4:hover .c16,
+  .c4:focus .c16 {
     opacity: 1;
   }
 
-  .c4:hover .c19 .c21 {
+  .c4:hover .c19 .c21,
+  .c4:focus .c19 .c21 {
     transform: scale(1.2);
   }
 }
@@ -316,19 +319,23 @@ exports[`renders correctly with data prop 1`] = `
     transform: translateY(-10px);
   }
 
-  .c4:hover .c5 img {
+  .c4:hover .c5 img,
+  .c4:focus .c5 img {
     transform: scale(1.06);
   }
 
-  .c4:hover .c14 {
+  .c4:hover .c14,
+  .c4:focus .c14 {
     color: #E52630;
   }
 
-  .c4:hover .c16 {
+  .c4:hover .c16,
+  .c4:focus .c16 {
     opacity: 1;
   }
 
-  .c4:hover .c19 .c21 {
+  .c4:hover .c19 .c21,
+  .c4:focus .c19 .c21 {
     transform: scale(1.2);
   }
 }
@@ -713,15 +720,18 @@ exports[`renders correctly without image 1`] = `
 }
 
 @media (min-width: 740px) {
-  .c4:hover .c10 {
+  .c4:hover .c10,
+  .c4:focus .c10 {
     color: #E52630;
   }
 
-  .c4:hover .c12 {
+  .c4:hover .c12,
+  .c4:focus .c12 {
     opacity: 1;
   }
 
-  .c4:hover .c15 .c17 {
+  .c4:hover .c15 .c17,
+  .c4:focus .c15 .c17 {
     transform: scale(1.2);
   }
 }
@@ -738,15 +748,18 @@ exports[`renders correctly without image 1`] = `
     transform: translateY(-10px);
   }
 
-  .c4:hover .c10 {
+  .c4:hover .c10,
+  .c4:focus .c10 {
     color: #E52630;
   }
 
-  .c4:hover .c12 {
+  .c4:hover .c12,
+  .c4:focus .c12 {
     opacity: 1;
   }
 
-  .c4:hover .c15 .c17 {
+  .c4:hover .c15 .c17,
+  .c4:focus .c15 .c17 {
     transform: scale(1.2);
   }
 }

--- a/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
+++ b/src/components/Molecules/CTA/CTASingleCard/__snapshots__/CTASingleCard.test.js.snap
@@ -114,6 +114,7 @@ exports[`renders correctly with data prop 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
+  transition: color 0.4s;
 }
 
 .c4 {
@@ -124,7 +125,7 @@ exports[`renders correctly with data prop 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -139,7 +140,7 @@ exports[`renders correctly with data prop 1`] = `
 
 .c4 .c5 img {
   transform: scale(1);
-  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.35s;
+  transition: transform 0.3s cubic-bezier(0.65,-0.19,0.37,1.16),box-shadow 0.4s;
 }
 
 .c2 {
@@ -311,7 +312,7 @@ exports[`renders correctly with data prop 1`] = `
   .c4 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
   }
 
   .c4:hover,
@@ -332,6 +333,11 @@ exports[`renders correctly with data prop 1`] = `
   .c4:hover .c16,
   .c4:focus .c16 {
     opacity: 1;
+  }
+
+  .c4:hover .c19,
+  .c4:focus .c19 {
+    background: #E52630;
   }
 
   .c4:hover .c19 .c21,
@@ -581,6 +587,7 @@ exports[`renders correctly without image 1`] = `
   text-decoration: none;
   position: relative;
   display: inline-block;
+  transition: color 0.4s;
 }
 
 .c4 {
@@ -591,7 +598,7 @@ exports[`renders correctly without image 1`] = `
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
   text-decoration: none;
   overflow: hidden;
@@ -740,7 +747,7 @@ exports[`renders correctly without image 1`] = `
   .c4 {
     transition: transform 0.30000000000000004s cubic-bezier(0.68,-0.8500000000000001,0.265,1.9500000000000002);
     transform-origin: center;
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.35s;
+    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35),box-shadow 0.4s;
   }
 
   .c4:hover,
@@ -756,6 +763,11 @@ exports[`renders correctly without image 1`] = `
   .c4:hover .c12,
   .c4:focus .c12 {
     opacity: 1;
+  }
+
+  .c4:hover .c15,
+  .c4:focus .c15 {
+    background: #E52630;
   }
 
   .c4:hover .c15 .c17,

--- a/src/components/Molecules/CTA/shared/CTACard.js
+++ b/src/components/Molecules/CTA/shared/CTACard.js
@@ -59,7 +59,7 @@ const CTACard = ({
         {...(hasLink ? { href: link, target, rel: external } : {})}
         $isCarousel={isCarousel}
         $isSingleCard={isSingleCard}
-        $isInteractive={hasLink}
+        $hasLink={hasLink}
       >
         {imageLow && (
           <ImageWrapper $isSingleCard={isSingleCard}>

--- a/src/components/Molecules/CTA/shared/CTACard.js
+++ b/src/components/Molecules/CTA/shared/CTACard.js
@@ -4,6 +4,8 @@ import Picture from '../../../Atoms/Picture/Picture';
 import Link from '../../../Atoms/Link/Link';
 import ArrowIcon from '../../shared/ctaArrow/ArrowIcon';
 import altCtaUnderline from '../../../../theme/shared/assets/alt_cta_underline.svg';
+import { CtaTextUnderline } from '../../shared/ctaText/ctaText.style';
+
 import {
   CardLink,
   ImageWrapper,
@@ -12,7 +14,6 @@ import {
   CardLabel,
   CTA,
   CTAText,
-  CTATextUnderline,
   ArrowIconOuter,
   ArrowIconInner,
   ArrowIconWrapper,
@@ -86,7 +87,7 @@ const CTACard = ({
             <CTA>
               <CTAText>
                 {linkLabel}
-                <CTATextUnderline
+                <CtaTextUnderline
                   src={altCtaUnderline}
                   alt=""
                   aria-hidden="true"

--- a/src/components/Molecules/CTA/shared/CTACard.style.js
+++ b/src/components/Molecules/CTA/shared/CTACard.style.js
@@ -74,11 +74,17 @@ const CardLink = styled.a`
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
+  transition: box-shadow 0.35s;
   ${defaultBoxShadow()}
   text-decoration: none;
   overflow: hidden;
-  cursor: ${({ $isInteractive }) => ($isInteractive ? 'pointer' : 'default')};
+  cursor: ${({ $hasLink }) => ($hasLink ? 'pointer' : 'default')};
   box-sizing: border-box;
+
+  &:hover,
+  &:focus {
+    ${defaultBoxShadow(true)}
+  }
 
   // Side-by-side layout for single card desktop view
   ${({ $isSingleCard }) => $isSingleCard && css`
@@ -94,17 +100,15 @@ const CardLink = styled.a`
     }
   `}
 
-  ${({ $isInteractive }) => $isInteractive && css`
+  ${({ $hasLink }) => $hasLink && css`
     ${ImageWrapper} img {
       ${imageZoom({ initialScale: 1 })}
     }
 
     @media ${({ theme }) => theme.allBreakpoints('M')} {
       &:hover {
-        ${defaultBoxShadow(true)}
 
         ${CTAText} {
-          text-decoration: none;
           color: ${({ theme }) => theme.color('red')};
         }
 
@@ -126,9 +130,10 @@ const CardLink = styled.a`
 
     // Desktop-only hover effects
     @media ${({ theme }) => theme.allBreakpoints('L')} {
+    
       ${bounceUpAnimation(true, 10, 1)};
-      /* override the bounceUpAnimation transition */
-      transition: transform 0.4s cubic-bezier(0.68, -1.15, 0.265, 2.35);
+      /* override the bounceUpAnimation transition, ensuring we don't lose the box-shadow animation */
+      transition: transform 0.4s cubic-bezier(0.68, -1.15, 0.265, 2.35), box-shadow 0.35s;
 
       &:hover {
         ${ImageWrapper} img {
@@ -136,12 +141,7 @@ const CardLink = styled.a`
         }
 
         ${CTAText} {
-          text-decoration: none;
-          
-          // TODO: mediaquery INSIDE a mediaquery? 🤔
-          @media (min-width: ${breakpointValues.L}px) {
-            color: ${({ theme }) => theme.color('red')};
-          }
+          color: ${({ theme }) => theme.color('red')};
         }
 
         ${CtaTextUnderline} {

--- a/src/components/Molecules/CTA/shared/CTACard.style.js
+++ b/src/components/Molecules/CTA/shared/CTACard.style.js
@@ -59,7 +59,7 @@ const CTAText = styled.span`
   text-decoration: none;
   position: relative;
   display: inline-block;
-  transition: color 0.4s;
+  transition: color 0.35s;
 
   @media (min-width: ${breakpointValues.L}px) {
     color: ${({ theme }) => theme.color('grey_4')};
@@ -75,7 +75,7 @@ const CardLink = styled.a`
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.4s;
+  transition: box-shadow 0.35s;
   ${defaultBoxShadow()}
   text-decoration: none;
   overflow: hidden;
@@ -135,7 +135,7 @@ const CardLink = styled.a`
     
       ${bounceUpAnimation(true, 10, 1)};
       /* override the bounceUpAnimation transition, ensuring we don't lose the box-shadow animation */
-      transition: transform 0.4s cubic-bezier(0.68, -1.15, 0.265, 2.35), box-shadow 0.4s;
+      transition: transform 0.35s cubic-bezier(0.68, -1.15, 0.265, 2.35), box-shadow 0.35s;
 
       &:hover,
       &:focus {

--- a/src/components/Molecules/CTA/shared/CTACard.style.js
+++ b/src/components/Molecules/CTA/shared/CTACard.style.js
@@ -95,7 +95,7 @@ const CardLink = styled.a`
   `}
 
   ${({ $isInteractive }) => $isInteractive && css`
-    img {
+    ${ImageWrapper} img {
       ${imageZoom({ initialScale: 1 })}
     }
 

--- a/src/components/Molecules/CTA/shared/CTACard.style.js
+++ b/src/components/Molecules/CTA/shared/CTACard.style.js
@@ -55,14 +55,14 @@ const ImageWrapper = styled.div`
 const CTAText = styled.span`
   ${({ theme }) => fontHelper(theme, 'span')}
   color: ${({ theme }) => theme.color('red')};
-
-  @media (min-width: ${breakpointValues.L}px) {
-    color: ${({ theme }) => theme.color('grey_4')};
-  }
   font-weight: bold;
   text-decoration: none;
   position: relative;
   display: inline-block;
+
+  @media (min-width: ${breakpointValues.L}px) {
+    color: ${({ theme }) => theme.color('grey_4')};
+  }
 `;
 
 // Card wrapper link - makes entire card clickable

--- a/src/components/Molecules/CTA/shared/CTACard.style.js
+++ b/src/components/Molecules/CTA/shared/CTACard.style.js
@@ -106,7 +106,8 @@ const CardLink = styled.a`
     }
 
     @media ${({ theme }) => theme.allBreakpoints('M')} {
-      &:hover {
+      &:hover,
+      &:focus {
 
         ${CTAText} {
           color: ${({ theme }) => theme.color('red')};
@@ -128,14 +129,15 @@ const CardLink = styled.a`
       }
     }
 
-    // Desktop-only hover effects
+    // Desktop-only hover/focus effects
     @media ${({ theme }) => theme.allBreakpoints('L')} {
     
       ${bounceUpAnimation(true, 10, 1)};
       /* override the bounceUpAnimation transition, ensuring we don't lose the box-shadow animation */
       transition: transform 0.4s cubic-bezier(0.68, -1.15, 0.265, 2.35), box-shadow 0.35s;
 
-      &:hover {
+      &:hover,
+      &:focus {
         ${ImageWrapper} img {
           ${imageZoom({ zoomed: true, finalScale: 1.06 })}
         }

--- a/src/components/Molecules/CTA/shared/CTACard.style.js
+++ b/src/components/Molecules/CTA/shared/CTACard.style.js
@@ -320,14 +320,12 @@ const CTA = styled.div`
 
 export {
   CardLink,
-  // CardsContainer,
   ImageWrapper,
   CopyAndLinkSection,
   Copy,
   CardLabel,
   CTA,
   CTAText,
-  // CTATextUnderline,
   CtaTextUnderline,
   ArrowIconOuter,
   ArrowIconInner,

--- a/src/components/Molecules/CTA/shared/CTACard.style.js
+++ b/src/components/Molecules/CTA/shared/CTACard.style.js
@@ -4,6 +4,7 @@ import { breakpointValues } from '../../../../theme/shared/allBreakpoints';
 import fontHelper from '../../../../theme/crTheme/fontHelper';
 import defaultBoxShadow from '../../../../theme/shared/boxShadows';
 import { ArrowIconInner, ArrowIconOuter, ArrowIconWrapper } from '../../shared/ctaArrow/CtaArrowCircle.style';
+import { CtaTextUnderline } from '../../shared/ctaText/ctaText.style';
 
 const ImageWrapper = styled.div`
   width: 100%;
@@ -64,17 +65,6 @@ const CTAText = styled.span`
   display: inline-block;
 `;
 
-const CTATextUnderline = styled.img`
-  height: 4px;
-  width: 100%;
-  position: absolute;
-  left: 0;
-  bottom: -5px;
-  transition: opacity 0.15s 0.1s;
-  opacity: 0;
-  pointer-events: none;
-`;
-
 // Card wrapper link - makes entire card clickable
 const CardLink = styled.a`
   display: flex;
@@ -109,27 +99,52 @@ const CardLink = styled.a`
       ${imageZoom({ initialScale: 1 })}
     }
 
-    // Desktop-only hover effects
     @media ${({ theme }) => theme.allBreakpoints('M')} {
+      &:hover {
+        ${defaultBoxShadow(true)}
+
+        ${CTAText} {
+          text-decoration: none;
+          color: ${({ theme }) => theme.color('red')};
+        }
+
+        ${CtaTextUnderline} {
+          opacity: 1;
+        }
+
+        ${ArrowIconWrapper} {
+          @media (min-width: ${breakpointValues.L}px) {
+            background: ${({ theme }) => theme.color('red')};
+          }
+
+          ${ArrowIconInner} {
+            transform: scale(1.2);
+          }
+        }
+      }
+    }
+
+    // Desktop-only hover effects
+    @media ${({ theme }) => theme.allBreakpoints('L')} {
       ${bounceUpAnimation(true, 10, 1)};
       /* override the bounceUpAnimation transition */
       transition: transform 0.4s cubic-bezier(0.68, -1.15, 0.265, 2.35);
 
       &:hover {
-        ${defaultBoxShadow(true)}
-
         ${ImageWrapper} img {
           ${imageZoom({ zoomed: true, finalScale: 1.06 })}
         }
 
         ${CTAText} {
           text-decoration: none;
+          
+          // TODO: mediaquery INSIDE a mediaquery? 🤔
           @media (min-width: ${breakpointValues.L}px) {
             color: ${({ theme }) => theme.color('red')};
           }
         }
 
-        ${CTATextUnderline} {
+        ${CtaTextUnderline} {
           opacity: 1;
         }
 
@@ -312,7 +327,8 @@ export {
   CardLabel,
   CTA,
   CTAText,
-  CTATextUnderline,
+  // CTATextUnderline,
+  CtaTextUnderline,
   ArrowIconOuter,
   ArrowIconInner,
   ArrowIconWrapper,

--- a/src/components/Molecules/CTA/shared/CTACard.style.js
+++ b/src/components/Molecules/CTA/shared/CTACard.style.js
@@ -59,6 +59,7 @@ const CTAText = styled.span`
   text-decoration: none;
   position: relative;
   display: inline-block;
+  transition: color 0.4s;
 
   @media (min-width: ${breakpointValues.L}px) {
     color: ${({ theme }) => theme.color('grey_4')};
@@ -74,7 +75,7 @@ const CardLink = styled.a`
   flex: 1 1 auto;
   background: transparent;
   border-radius: 1rem;
-  transition: box-shadow 0.35s;
+  transition: box-shadow 0.4s;
   ${defaultBoxShadow()}
   text-decoration: none;
   overflow: hidden;
@@ -134,7 +135,7 @@ const CardLink = styled.a`
     
       ${bounceUpAnimation(true, 10, 1)};
       /* override the bounceUpAnimation transition, ensuring we don't lose the box-shadow animation */
-      transition: transform 0.4s cubic-bezier(0.68, -1.15, 0.265, 2.35), box-shadow 0.35s;
+      transition: transform 0.4s cubic-bezier(0.68, -1.15, 0.265, 2.35), box-shadow 0.4s;
 
       &:hover,
       &:focus {
@@ -151,9 +152,7 @@ const CardLink = styled.a`
         }
 
         ${ArrowIconWrapper} {
-          @media (min-width: ${breakpointValues.L}px) {
-            background: ${({ theme }) => theme.color('red')};
-          }
+          background: ${({ theme }) => theme.color('red')};
 
           ${ArrowIconInner} {
             transform: scale(1.2);

--- a/src/components/Molecules/HeroBanner/HeroBanner.js
+++ b/src/components/Molecules/HeroBanner/HeroBanner.js
@@ -61,17 +61,16 @@ const HeroBanner = ({
         <CTAWrapper $variant={variant}>
           {(variant !== variants.TEXT_BANNER) ? (
             <>
-              <CtaText className="cta">
+              <CtaText>
                 {ctaText}
                 <CtaTextUnderline
                   src={altCtaUnderline}
                   alt={ctaText}
-                  className="cta-text-underline"
                 />
               </CtaText>
 
               <CtaIconWrapper>
-                <ArrowIconWrapper $preventHoverColourChange>
+                <ArrowIconWrapper>
                   <ArrowIconInner>
                     <ArrowIcon />
                   </ArrowIconInner>

--- a/src/components/Molecules/HeroBanner/HeroBanner.style.js
+++ b/src/components/Molecules/HeroBanner/HeroBanner.style.js
@@ -86,7 +86,7 @@ const MediaWrapper = styled.div`
 
       // Zoom the image in slightly by default so the 'bounce' animation doesn't cause issues
       transform: scale(1.02);
-      transition: transform 0.4s cubic-bezier(0.68, -1.15, 0.265, 2.35);
+      transition: transform 0.35s cubic-bezier(0.68, -1.15, 0.265, 2.35);
 
       ${({ $variant }) => ($variant === variants.HALF_HEIGHT && 'min-height: 450px;')};
    }
@@ -214,7 +214,7 @@ const HeroBannerLink = styled.a`
   width: 100%;
 
   > div {
-    transition: box-shadow 0.4s;
+    transition: box-shadow 0.35s;
     ${defaultBoxShadow()}
   }
 

--- a/src/components/Molecules/HeroBanner/HeroBanner.style.js
+++ b/src/components/Molecules/HeroBanner/HeroBanner.style.js
@@ -218,6 +218,15 @@ const HeroBannerLink = styled.a`
     }
   }
 
+  @media ${({ theme }) => theme.breakpoints2026('M')} {
+    // Fade in the 'Alt CTA'-style squiggley underline:
+    &:hover {
+      img.cta-text-underline {
+        opacity: 1;
+      }
+    }
+  }
+
   @media ${({ theme }) => theme.breakpoints2026('L')} {
 
     ${bounceUpAnimation(true, 10, 2, true)}
@@ -227,13 +236,6 @@ const HeroBannerLink = styled.a`
 
     > div {
       width: 100%;
-    }
-
-    // Fade in the 'Alt CTA'-style squiggley underline:
-    &:hover {
-      img.cta-text-underline {
-        opacity: 1;
-      }
     }
   }
 

--- a/src/components/Molecules/HeroBanner/HeroBanner.style.js
+++ b/src/components/Molecules/HeroBanner/HeroBanner.style.js
@@ -4,6 +4,8 @@ import { bounceUpAnimation, playPauseReveal } from '../../../theme/shared/animat
 import defaultBoxShadow from '../../../theme/shared/boxShadows';
 import { ArrowIconWrapper, ArrowIconInner } from '../shared/ctaArrow/CtaArrowCircle.style';
 import Picture from '../../Atoms/Picture/Picture';
+import { CtaText, CtaTextUnderline } from '../shared/ctaText/ctaText.style';
+// import { , CtaIconWrapper, CtaText } from '../shared/ctaText/ctaText.style';
 
 // Lil helper function to streamline things somewhat:
 const handleVariant = variant => {
@@ -196,9 +198,13 @@ const CTAWrapper = styled.div`
   ${({ $variant }) => ($variant !== variants.TEXT_BANNER && css`
     padding-right: 2.5rem;
 
-    span {
+    ${CtaText} {
       font-weight: bold;
       color: ${({ theme }) => theme.color('red')};
+
+      @media ${({ theme }) => theme.breakpoints2026('L')} {
+        color: ${({ theme }) => theme.color('black')};
+      }
     }
   `)}
 `;
@@ -216,13 +222,22 @@ const HeroBannerLink = styled.a`
     > div {
       ${defaultBoxShadow(true)}
     }
+
+    @media ${({ theme }) => theme.breakpoints2026('L')} {
+      ${CtaText} {
+        color: ${({ theme }) => theme.color('red')};
+      }
+    }
   }
 
-  @media ${({ theme }) => theme.breakpoints2026('M')} {
-    // Fade in the 'Alt CTA'-style squiggley underline:
+  @media ${({ theme }) => theme.allBreakpoints('M')} {
     &:hover {
-      img.cta-text-underline {
+      ${CtaTextUnderline}  {
         opacity: 1;
+      }
+
+      ${ArrowIconWrapper} ${ArrowIconInner} {
+        transform: scale(1.2);
       }
     }
   }
@@ -237,12 +252,10 @@ const HeroBannerLink = styled.a`
     > div {
       width: 100%;
     }
-  }
 
-  @media ${({ theme }) => theme.allBreakpoints('M')} {
     &:hover {
-      ${ArrowIconWrapper} ${ArrowIconInner} {
-        transform: scale(1.2);
+      ${ArrowIconWrapper} {
+        background: ${({ theme }) => theme.color('red')};
       }
     }
   }

--- a/src/components/Molecules/HeroBanner/HeroBanner.style.js
+++ b/src/components/Molecules/HeroBanner/HeroBanner.style.js
@@ -91,7 +91,8 @@ const MediaWrapper = styled.div`
       ${({ $variant }) => ($variant === variants.HALF_HEIGHT && 'min-height: 450px;')};
    }
 
-    &:has(+ div a:hover) {
+    &:has(+ div a:hover),
+    &:has(+ div a:focus) {
       > div > img {
         transform: scale(1.04);
       }
@@ -217,7 +218,8 @@ const HeroBannerLink = styled.a`
     ${defaultBoxShadow()}
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     > div {
       ${defaultBoxShadow(true)}
     }
@@ -230,7 +232,8 @@ const HeroBannerLink = styled.a`
   }
 
   @media ${({ theme }) => theme.allBreakpoints('M')} {
-    &:hover {
+    &:hover,
+    &:focus {
       ${CtaTextUnderline}  {
         opacity: 1;
       }
@@ -252,7 +255,8 @@ const HeroBannerLink = styled.a`
       width: 100%;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       ${ArrowIconWrapper} {
         background: ${({ theme }) => theme.color('red')};
       }

--- a/src/components/Molecules/HeroBanner/HeroBanner.style.js
+++ b/src/components/Molecules/HeroBanner/HeroBanner.style.js
@@ -5,7 +5,6 @@ import defaultBoxShadow from '../../../theme/shared/boxShadows';
 import { ArrowIconWrapper, ArrowIconInner } from '../shared/ctaArrow/CtaArrowCircle.style';
 import Picture from '../../Atoms/Picture/Picture';
 import { CtaText, CtaTextUnderline } from '../shared/ctaText/ctaText.style';
-// import { , CtaIconWrapper, CtaText } from '../shared/ctaText/ctaText.style';
 
 // Lil helper function to streamline things somewhat:
 const handleVariant = variant => {

--- a/src/components/Molecules/HeroBanner/HeroBanner.style.js
+++ b/src/components/Molecules/HeroBanner/HeroBanner.style.js
@@ -200,6 +200,7 @@ const CTAWrapper = styled.div`
 
     ${CtaText} {
       font-weight: bold;
+      transition: color 0.35s;
       color: ${({ theme }) => theme.color('red')};
 
       @media ${({ theme }) => theme.breakpoints2026('L')} {

--- a/src/components/Molecules/HeroBanner/HeroBanner.style.js
+++ b/src/components/Molecules/HeroBanner/HeroBanner.style.js
@@ -214,7 +214,7 @@ const HeroBannerLink = styled.a`
   width: 100%;
 
   > div {
-    transition: box-shadow 0.35s;
+    transition: box-shadow 0.4s;
     ${defaultBoxShadow()}
   }
 

--- a/src/components/Molecules/HeroBanner/__snapshots__/HeroBanner.test.js.snap
+++ b/src/components/Molecules/HeroBanner/__snapshots__/HeroBanner.test.js.snap
@@ -171,7 +171,8 @@ exports[`renders "Full Height Media" Hero Banner correctly 1`] = `
     transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
   }
 
-  .c2:has(+ div a:hover) >div>img {
+  .c2:has(+ div a:hover) >div>img,
+  .c2:has(+ div a:focus) >div>img {
     transform: scale(1.04);
   }
 }
@@ -445,7 +446,8 @@ exports[`renders "Half Height Media" Hero Banner correctly 1`] = `
     min-height: 450px;
   }
 
-  .c2:has(+ div a:hover) >div>img {
+  .c2:has(+ div a:hover) >div>img,
+  .c2:has(+ div a:focus) >div>img {
     transform: scale(1.04);
   }
 }
@@ -963,7 +965,8 @@ exports[`renders "Text Banner" Hero Banner correctly 2`] = `
     transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
   }
 
-  .c2:has(+ div a:hover) >div>img {
+  .c2:has(+ div a:hover) >div>img,
+  .c2:has(+ div a:focus) >div>img {
     transform: scale(1.04);
   }
 }

--- a/src/components/Molecules/HeroBanner/__snapshots__/HeroBanner.test.js.snap
+++ b/src/components/Molecules/HeroBanner/__snapshots__/HeroBanner.test.js.snap
@@ -168,7 +168,7 @@ exports[`renders "Full Height Media" Hero Banner correctly 1`] = `
     object-position: top center;
     height: 100%;
     transform: scale(1.02);
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
+    transition: transform 0.35s cubic-bezier(0.68,-1.15,0.265,2.35);
   }
 
   .c2:has(+ div a:hover) >div>img,
@@ -442,7 +442,7 @@ exports[`renders "Half Height Media" Hero Banner correctly 1`] = `
     object-position: top center;
     height: 100%;
     transform: scale(1.02);
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
+    transition: transform 0.35s cubic-bezier(0.68,-1.15,0.265,2.35);
     min-height: 450px;
   }
 
@@ -962,7 +962,7 @@ exports[`renders "Text Banner" Hero Banner correctly 2`] = `
     object-position: top center;
     height: 100%;
     transform: scale(1.02);
-    transition: transform 0.4s cubic-bezier(0.68,-1.15,0.265,2.35);
+    transition: transform 0.35s cubic-bezier(0.68,-1.15,0.265,2.35);
   }
 
   .c2:has(+ div a:hover) >div>img,

--- a/src/components/Molecules/shared/ctaArrow/CtaArrowCircle.style.js
+++ b/src/components/Molecules/shared/ctaArrow/CtaArrowCircle.style.js
@@ -1,5 +1,4 @@
-import styled, { css } from 'styled-components';
-import { breakpointValues } from '../../../../theme/shared/allBreakpoints';
+import styled from 'styled-components';
 
 const ArrowIconInner = styled.span`
   display: inline-flex;
@@ -16,11 +15,9 @@ const ArrowIconWrapper = styled.div`
   border-radius: 50%;
   background: ${({ theme }) => theme.color('red')};
 
-  ${({ $preventHoverColourChange }) => !$preventHoverColourChange && css`
-    @media (min-width: ${breakpointValues.L}px) {
-      background: ${({ theme }) => theme.color('grey_4')};
-    }
-  `}
+  @media ${({ theme }) => theme.breakpoints2026('L')} {
+    background: ${({ theme }) => theme.color('grey_4')};
+  }
 
   display: flex;
   align-items: center;

--- a/src/components/Molecules/shared/ctaArrow/CtaArrowCircle.style.js
+++ b/src/components/Molecules/shared/ctaArrow/CtaArrowCircle.style.js
@@ -4,7 +4,7 @@ const ArrowIconInner = styled.span`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.3s cubic-bezier(0.65, -0.19, 0.37, 1.16);
+  transition: transform 0.35s cubic-bezier(0.65, -0.19, 0.37, 1.16);
   transform: scale(1);
   transform-origin: center;
 `;

--- a/src/components/Molecules/shared/ctaText/ctaText.style.js
+++ b/src/components/Molecules/shared/ctaText/ctaText.style.js
@@ -9,6 +9,7 @@ const CtaTextUnderline = styled.img`
   bottom: -5px;
   transition: opacity 0.15s 0.1s;
   opacity: 0;
+  pointer-events: none;
 `;
 
 const CtaIconWrapper = styled.div`

--- a/src/components/Organisms/DonateBanner/Form/PopUpComponent.js
+++ b/src/components/Organisms/DonateBanner/Form/PopUpComponent.js
@@ -38,7 +38,7 @@ const StyledPopUp = styled.div`
   overflow: hidden;
   max-height: 350px;
   opacity: 1;
-  animation: 0.4s ${props => props.fadeOpen} ease;
+  animation: 0.35s ${props => props.fadeOpen} ease;
   ${props => props.isClosed && css`
     animation: ${closeDuration}s ${props.fadeClose} ease forwards;
   `}

--- a/src/theme/shared/animations.js
+++ b/src/theme/shared/animations.js
@@ -31,7 +31,7 @@ const pulseOut = keyframes`
 `;
 
 const pulseInAnimation = css`
-  animation: ${pulseIn} 0.4s ease-in-out forwards;
+  animation: ${pulseIn} 0.35s ease-in-out forwards;
 `;
 
 const pulseOutAnimation = css`
@@ -122,7 +122,7 @@ const imageZoom = (params = {}) => {
     transform: scale(${initialScale});
     // Also including the box-shadow transform so we don't override it on breakpoints this 
     // transform is applied to (especially since we're generally using them together):
-    transition: transform 0.3s cubic-bezier(0.65, -0.19, 0.37, 1.16), box-shadow 0.4s;
+    transition: transform 0.35s cubic-bezier(0.65, -0.19, 0.37, 1.16), box-shadow 0.35s;
   ` : css`
     transform: scale(${finalScale});
   `;

--- a/src/theme/shared/animations.js
+++ b/src/theme/shared/animations.js
@@ -122,7 +122,7 @@ const imageZoom = (params = {}) => {
     transform: scale(${initialScale});
     // Also including the box-shadow transform so we don't override it on breakpoints this 
     // transform is applied to (especially since we're generally using them together):
-    transition: transform 0.3s cubic-bezier(0.65, -0.19, 0.37, 1.16), box-shadow 0.35s;
+    transition: transform 0.3s cubic-bezier(0.65, -0.19, 0.37, 1.16), box-shadow 0.4s;
   ` : css`
     transform: scale(${finalScale});
   `;

--- a/src/theme/shared/animations.js
+++ b/src/theme/shared/animations.js
@@ -120,8 +120,8 @@ const imageZoom = (params = {}) => {
 
   return !zoomed ? css`
     transform: scale(${initialScale});
-    // Also including the box-shadow transform so we don't lose on breakpoints this 
-    // is applied to, especially since we're generally using them together:
+    // Also including the box-shadow transform so we don't override it on breakpoints this 
+    // transform is applied to (especially since we're generally using them together):
     transition: transform 0.3s cubic-bezier(0.65, -0.19, 0.37, 1.16), box-shadow 0.35s;
   ` : css`
     transform: scale(${finalScale});

--- a/src/theme/shared/animations.js
+++ b/src/theme/shared/animations.js
@@ -120,7 +120,9 @@ const imageZoom = (params = {}) => {
 
   return !zoomed ? css`
     transform: scale(${initialScale});
-    transition: transform 0.3s cubic-bezier(0.65, -0.19, 0.37, 1.16);
+    // Also including the box-shadow transform so we don't lose on breakpoints this 
+    // is applied to, especially since we're generally using them together:
+    transition: transform 0.3s cubic-bezier(0.65, -0.19, 0.37, 1.16), box-shadow 0.35s;
   ` : css`
     transform: scale(${finalScale});
   `;


### PR DESCRIPTION
### PR description
#### What is it doing?
As per clarifications laid out in the ticket "Uncovered during some other work, here’s the official list from @CurtisPage ":

**XS/SM:**
- Alt cta by default - **Red**
- Alt cta with underline on hover/tap (red alt cta) - **No, stay just red**
- Bounce up on hover/tap - **No**
- Image zoom on hover/tap - **No**
- Shadow change on hover/tap - **Yes**

**M:**
- Alt cta by default - **Red**
- Alt cta with underline on hover/tap (red alt cta) - **Yes**
- Bounce up on hover/tap - **No**
- Image zoom on hover/tap - **No**
- Shadow change on hover - **Yes**

**L+:**
- Alt cta by default - **Black**
- Alt cta with underline on hover (red alt cta) - **Yes**
- Bounce up on hover - **Yes**
- Image zoom on hover - **Yes**
- Shadow change on hover - **Yes**

(and associated tweaks to other shared components and the other context they're used in)

#### Why is this required?
Bringing stuff inline for consistent design language across these components

#### link to Jira ticket:
https://comicrelief.atlassian.net/browse/ENG-5146

### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
