### PR TITLE
fix: ENG-5245 - refactor RichText carousel

### DIFF
--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.js
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useState, useCallback
+  useEffect, useState
 } from 'react';
 import PropTypes from 'prop-types';
 
@@ -28,45 +28,12 @@ const RichtextCarousel = ({
     rowBackgroundColour = 'grey_light'
   }
 }) => {
-  // Defaults to mobile config:
-  const [isMobile, setIsMobile] = useState(true);
-  const [visibleSlides, setVisibleSlides] = useState(1);
-  const [totalSlides, setTotalSlides] = useState(null);
   const [theseItems, setTheseItems] = useState();
-
-  // Custom function to let us update the carousel config dynamically
-  const screenResize = useCallback(() => {
-    const screenSize = typeof window !== 'undefined' ? window.innerWidth : null;
-    const isCurrentlyMobile = window.innerWidth < breakpointValues.M;
-
-    if (screenSize !== null && (isMobile !== isCurrentlyMobile)) {
-      setIsMobile(isCurrentlyMobile);
-      setVisibleSlides(isCurrentlyMobile ? 1 : 3);
-      setTotalSlides(isCurrentlyMobile ? theseItems.length : theseItems.length + 2);
-    }
-  }, [isMobile, theseItems]);
 
   // Cache our data source, using as a flag for render logic:
   useEffect(() => {
     setTheseItems(nodes);
   }, [setTheseItems, nodes]);
-
-  useEffect(() => {
-    if (window !== 'undefined' && window.innerWidth >= breakpointValues.M) {
-      // On inital render, update carousel plugin config
-      // to suit the non-mobile layout and functionality:
-      setIsMobile(false);
-      setVisibleSlides(3);
-    }
-
-    // Hook into browser's own onresize event to call our custom wrapper function:
-    if (typeof window !== 'undefined') window.onresize = screenResize;
-  }, [screenResize]);
-
-  if (theseItems && totalSlides === null) {
-    // Reflects our two dummy/bookend slides for non-mobile/tablet views:
-    setTotalSlides(isMobile ? theseItems.length : theseItems.length + 2);
-  }
 
   return (
     <Container
@@ -89,45 +56,42 @@ const RichtextCarousel = ({
         </HeadingCopyWrapper>
 
         {theseItems && (
-        <Splide
-          className="richtext-carousel"
-          options={{
-            speed: 1000,
-            arrows: true,
-            pagination: false,
-            drag: 'free',
-            flickPower: 50,
-            perMove: 1,
-            perPage: visibleSlides,
-            dragMinThreshold: { mouse: 50, touch: 50 },
-            updateOnMove: true,
-            snap: true,
-            autoplay: autoPlay
-          }}
-        >
-
-          {/* Dummy slide for our desired non-mobile layout and functionality */}
-          {isMobile === false && (
-          <SplideSlide
-            index={0}
-            key={0}
-            className="bookend-first"
-          />
-          )}
-
+          <Splide
+            className="richtext-carousel"
+            options={{
+              speed: 1000,
+              arrows: true,
+              pagination: false,
+              drag: 'free',
+              flickPower: 50,
+              perMove: 1,
+              dragMinThreshold: { mouse: 50, touch: 50 },
+              updateOnMove: true,
+              snap: true,
+              autoplay: autoPlay,
+              focus: 'center',
+              trimSpace: false,
+              perPage: 3,
+              rewind: true,
+              breakpoints: {
+                [breakpointValues.M]: {
+                  perPage: 1
+                }
+              }
+            }}
+          >
             {Object.keys(theseItems).map((key, index) => {
-            // Reflect that initial dummy/bookend slide shown on non-mobile/tablet views:
-              const thisOffsetIndex = index + (isMobile ? 0 : 1);
+              const safeIndex = index;
 
               return (
-              // Calculate the index offset accordingly to reflect the number of slides,
-              // but use the REAL index when determining if its the last REAL slide
+                // Calculate the index offset accordingly to reflect the number of slides,
+                // but use the REAL index when determining if its the last REAL slide
                 <SplideSlide
-                  index={thisOffsetIndex}
                   className={index === (theseItems.length - 1) && 'last-slide'}
-                  key={thisOffsetIndex}
+                  key={safeIndex}
+                  index={safeIndex}
+                  data-index={safeIndex}
                 >
-
                   <SlideCopyWrapper
                     className="slide-copy-wrapper"
                     $mobileHeight={mobileHeight}
@@ -142,18 +106,10 @@ const RichtextCarousel = ({
                 </SplideSlide>
               );
             })}
-
-            {/* Dummy slide for our desired non-mobile layout and functionality */}
-            {isMobile === false && (
-            <SplideSlide index={theseItems.length + 1} key="bookend-last" />
-            )}
-
-        </Splide>
+          </Splide>
         )}
-
       </CarouselWrapper>
     </Container>
-
   );
 };
 

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.js
@@ -40,6 +40,7 @@ const RichtextCarousel = ({
       $paddingTop={paddingTop}
       $paddingBottom={paddingBottom}
       $rowBackgroundColour={rowBackgroundColour}
+      data-testid="richtext-carousel--container"
     >
 
       <CarouselWrapper
@@ -49,15 +50,17 @@ const RichtextCarousel = ({
         $tabletHeight={tabletHeight}
         $desktopHeight={desktopHeight}
         $carouselBackgroundColour={carouselBackgroundColour}
+        data-testid="richtext-carousel--wrapper"
       >
 
-        <HeadingCopyWrapper>
+        <HeadingCopyWrapper data-testid="richtext-carousel--heading">
           {headingCopy}
         </HeadingCopyWrapper>
 
         {theseItems && (
           <Splide
             className="richtext-carousel"
+            data-testid="richtext-carousel--splide"
             options={{
               speed: 1000,
               arrows: true,
@@ -91,6 +94,7 @@ const RichtextCarousel = ({
                   key={safeIndex}
                   index={safeIndex}
                   data-index={safeIndex}
+                  data-testid="richtext-carousel--slide"
                 >
                   <SlideCopyWrapper
                     className="slide-copy-wrapper"
@@ -99,6 +103,7 @@ const RichtextCarousel = ({
                     $desktopHeight={desktopHeight}
                     $nodeBackgroundColour={nodeBackgroundColour}
                     $nodeOutlineColour={nodeOutlineColour}
+                    data-testid="richtext-carousel--copy"
                   >
                     {theseItems[index].copy}
                   </SlideCopyWrapper>

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.js
@@ -2,10 +2,9 @@ import React, {
   useEffect, useState, useCallback
 } from 'react';
 import PropTypes from 'prop-types';
-import {
-  CarouselProvider, Slider, Slide, ButtonBack, ButtonNext
-} from 'pure-react-carousel';
-import 'pure-react-carousel/dist/react-carousel.es.css';
+
+import { Splide, SplideSlide } from '@splidejs/react-splide';
+
 import {
   CarouselWrapper, SlideCopyWrapper, HeadingCopyWrapper, Container
 } from './RichtextCarousel.style';
@@ -90,21 +89,31 @@ const RichtextCarousel = ({
         </HeadingCopyWrapper>
 
         {theseItems && (
-        <CarouselProvider
-          naturalSlideWidth={50}
-          naturalSlideHeight={200}
-          totalSlides={totalSlides}
-          isPlaying={autoPlay}
-          interval={5000}
-          visibleSlides={visibleSlides}
-          infinite
+        <Splide
+          className="richtext-carousel"
+          options={{
+            speed: 1000,
+            arrows: true,
+            pagination: false,
+            drag: 'free',
+            flickPower: 50,
+            perMove: 1,
+            perPage: visibleSlides,
+            dragMinThreshold: { mouse: 50, touch: 50 },
+            updateOnMove: true,
+            snap: true,
+            autoplay: autoPlay
+          }}
         >
-          <Slider classNameAnimation="richtext-carousel">
 
-            {/* Dummy slide for our desired non-mobile layout and functionality */}
-            {isMobile === false && (
-            <Slide index={0} key={0} />
-            )}
+          {/* Dummy slide for our desired non-mobile layout and functionality */}
+          {isMobile === false && (
+          <SplideSlide
+            index={0}
+            key={0}
+            className="bookend-first"
+          />
+          )}
 
             {Object.keys(theseItems).map((key, index) => {
             // Reflect that initial dummy/bookend slide shown on non-mobile/tablet views:
@@ -113,7 +122,7 @@ const RichtextCarousel = ({
               return (
               // Calculate the index offset accordingly to reflect the number of slides,
               // but use the REAL index when determining if its the last REAL slide
-                <Slide
+                <SplideSlide
                   index={thisOffsetIndex}
                   className={index === (theseItems.length - 1) && 'last-slide'}
                   key={thisOffsetIndex}
@@ -130,19 +139,16 @@ const RichtextCarousel = ({
                     {theseItems[index].copy}
                   </SlideCopyWrapper>
 
-                </Slide>
+                </SplideSlide>
               );
             })}
 
             {/* Dummy slide for our desired non-mobile layout and functionality */}
             {isMobile === false && (
-            <Slide index={theseItems.length + 1} key="bookend-last" />
+            <SplideSlide index={theseItems.length + 1} key="bookend-last" />
             )}
 
-          </Slider>
-          <ButtonBack>Back</ButtonBack>
-          <ButtonNext>Next</ButtonNext>
-        </CarouselProvider>
+        </Splide>
         )}
 
       </CarouselWrapper>

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
@@ -47,15 +47,13 @@ const HeadingCopyWrapper = styled.div`
 const CarouselWrapper = styled.div`
   height: 100%;
   background: ${({ theme, $carouselBackgroundColour }) => theme.color($carouselBackgroundColour)};
-  
   max-width: 760px;
   padding: 2.5rem ${spacing('l')} 3.5rem;
   margin: 0 auto;
-
   border-radius: 20px;
   ${defaultBoxShadow()}
 
-  > div:first-child {
+  ${HeadingCopyWrapper} {
     * {
       margin-top: 0;
     }
@@ -92,6 +90,7 @@ const CarouselWrapper = styled.div`
       background-color: transparent;
       transform: none;
       border-radius: 0;
+      opacity: 1;
 
       &:after {
         content: "";
@@ -132,14 +131,8 @@ const CarouselWrapper = styled.div`
       }
     }
 
-    
+    // Carousel:
     &.richtext-carousel {
-      .last-slide {
-        ${SlideCopyWrapper}:after {
-          content: none;
-        }
-      }
-
       // All sides:
       .splide__slide  {
         text-align: center;
@@ -147,10 +140,15 @@ const CarouselWrapper = styled.div`
         align-items: center;
         justify-content: flex-start;
         flex-direction: column;
-
         padding-bottom: ${props => props.$mobileHeight}px;
 
-
+        &.last-slide {
+          ${SlideCopyWrapper} {
+            &:after {
+              content: none !important;
+            }
+          }
+        }
         
         // 'Tablet' (and up) tweaks for the 3-visible layout
         @media ${({ theme }) => theme.allBreakpoints('M')} {
@@ -166,97 +164,22 @@ const CarouselWrapper = styled.div`
               transition: transform ${animationSpeed}s ease,
               width ${animationSpeed}s ease,
               right ${animationSpeed}s ease;
-              width: 100%;
-              right: calc(-100% - 6px);
+              width: 33%;
+              right: calc(-33% - 1px);
               transform: scale(1);
             }
           }
 
-          // Our 'first' slide of the three:
           &.is-active {
-            //
-          }
-
-          // Middle slide:
-          &.is-next {
             ${SlideCopyWrapper} {
               transform: scale(1.0);
-            }
+            } 
           }
+        }
 
-          // 2nd and 3rd:
-          // + .carousel__slide--visible {
-          //   .carousel__inner-slide {
-          //     > ${SlideCopyWrapper} {
-          //       transform: scale(1);
-          //       &:after {
-          //         width: 33%;
-          //         right: calc(-33% + 3px);
-          //         transform: scale(0.8);
-          //       }
-          //     }
-          //   }
-          // }
-
-          // Resets the 3rd slide:
-          //  + .carousel__slide--visible {
-          //      > ${SlideCopyWrapper} {
-          //        transform: scale(0.8);
-          //        &:after {
-          //          width: 50%;
-          //          right: calc(-50% - 6px);
-          //          transform: scale(1);
-          //        }
-          //      }
-          //    }
-          //  }
-
-        } // End of M breakpoint
-
-
-        
         // 'Desktop'
         @media ${({ theme }) => theme.allBreakpoints('L')} {
           padding-bottom: ${props => props.$desktopHeight}px;
-
-          // First
-          &.carousel__slide--visible {
-
-            // 2nd and 3rd
-            + .carousel__slide--visible {
-
-              // 3rd only
-              + .carousel__slide--visible {
-                .carousel__inner-slide {
-                  > div:first-child {
-                    &:after {
-                      right: calc(-125% - 5px);
-                      width: 125%;
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        // END OF DESKTOP
-
-        .carousel__inner-slide {
-          text-align: center;
-          display: inline-flex;
-          align-items: center;
-          justify-content: flex-start;
-          flex-direction: column;
-
-          ${SlideCopyWrapper} {
-            font-size: 0.9rem;
-            line-height: 0.9rem;
-
-            * {
-              font-size: inherit;
-              line-height: inherit;
-            }
-          }
         }
       }
     }

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
@@ -171,8 +171,8 @@ const CarouselWrapper = styled.div`
               transition: transform ${animationSpeed}s ease,
               width ${animationSpeed}s ease,
               right ${animationSpeed}s ease;
-              width: 33%;
-              right: calc(-33% - 1px);
+              width: 50%;
+              right: calc(-50% - 1px);
               transform: scale(1);
             }
           }

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
@@ -65,23 +65,33 @@ const CarouselWrapper = styled.div`
     }
   }
 
-  .carousel {
+  .splide {
     position: relative;
     margin: 0 auto;
     padding-top: ${spacing('l')};
 
-    button.carousel__back-button,
-    button.carousel__next-button {
+    // Navigation buttons:
+    .splide__arrows {
+      width: 100%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+    }
+
+    button.splide__arrow {
       position: absolute;
       left: 0;
       top: 0;
-      width: 33% !important;
+      width: 33.3%;
       height: 100%;
-      padding: 0 !important;
+      padding: 0;
       box-shadow: none;
       text-indent: -9999px;
       background-color: transparent;
-      border: none;
+      transform: none;
+      border-radius: 0;
 
       &:after {
         content: "";
@@ -97,126 +107,117 @@ const CarouselWrapper = styled.div`
         `};
       }
 
+      &.splide__arrow--next {
+        left: auto;
+        right: 0;
+
+        &:after {
+          left: auto;
+          right: 0;
+          background: ${({ theme, $carouselBackgroundColour }) => css`
+          linear-gradient(90deg, ${theme.color($carouselBackgroundColour)}00,
+          ${theme.color($carouselBackgroundColour)}7a, ${theme.color($carouselBackgroundColour)});
+        `};
+        }
+      }
+
       &:hover {
         &:after {
           opacity: 0.5;
         }
       }
 
-      @media ${({ theme }) => theme.allBreakpoints('M')} {
-        width: 33.3% !important;
-        &:after {
-          width: 100%;
-        }
+      svg {
+        display: none;
       }
     }
 
-    button.carousel__next-button {
-      left: auto;
-      right: 0;
-
-      &:before {
-        transform: translate(0, -50%) rotate(-90deg);
-      }
-
-      &:after {
-        left: auto;
-        right: 0;
-
-        background: ${({ theme, $carouselBackgroundColour }) => css`
-          linear-gradient(90deg, ${theme.color($carouselBackgroundColour)}00,
-          ${theme.color($carouselBackgroundColour)}7a, ${theme.color($carouselBackgroundColour)});
-        `};
-      }
-    }
-
-    .richtext-carousel {
-      // Override default animations
-      transition: -webkit-transform ${animationSpeed}s;
-      -o-transition: transform ${animationSpeed}s;
-      transition: transform ${animationSpeed}s;
-      -webkit-transform: ${animationSpeed}s;
-      will-change: transform;
-
+    
+    &.richtext-carousel {
       .last-slide {
-        .slide-copy-wrapper:after {
+        ${SlideCopyWrapper}:after {
           content: none;
         }
       }
 
-      .carousel__slide {
-        // 'Mobile'
-        padding-bottom: ${props => props.$mobileHeight}px !important;
+      // All sides:
+      .splide__slide  {
+        text-align: center;
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-start;
+        flex-direction: column;
 
+        padding-bottom: ${props => props.$mobileHeight}px;
+
+
+        
         // 'Tablet' (and up) tweaks for the 3-visible layout
         @media ${({ theme }) => theme.allBreakpoints('M')} {
+          padding-bottom: ${props => props.$tabletHeight}px;
 
-          padding-bottom: ${props => props.$tabletHeight}px !important;
+           // All 'SlideCopyWrapper's:
+          ${SlideCopyWrapper} {
+            transition: transform ${animationSpeed}s ease;
+            transform-origin: center;
+            transform: scale(0.8);
 
-          // All slides:
-          .carousel__inner-slide {
-
-            // All 'SlideCopyWrapper's:
-            > div:first-child {
-              transition: transform ${animationSpeed}s ease;
-              transform-origin: center;
-              transform: scale(0.8);
-
-              &:after {
-                transition: transform ${animationSpeed}s ease,
-                width ${animationSpeed}s ease,
-                right ${animationSpeed}s ease;
-                width: 100%;
-                right: calc(-100% - 6px);
-                transform: scale(1);
-
-              }
+            &:after {
+              transition: transform ${animationSpeed}s ease,
+              width ${animationSpeed}s ease,
+              right ${animationSpeed}s ease;
+              width: 100%;
+              right: calc(-100% - 6px);
+              transform: scale(1);
             }
           }
 
           // Our 'first' slide of the three:
-          &.carousel__slide--visible {
-            .carousel__inner-slide {
-              > div:first-child {
-                &:after {
-                  width: 33%;
-                  right: calc(-33% - 3px);
-                  transform: scale(1);
-                }
-              }
-            }
+          &.is-active {
+            //
+          }
 
-            // 2nd and 3rd:
-            + .carousel__slide--visible {
-              .carousel__inner-slide {
-                > div:first-child {
-                  transform: scale(1);
-                  &:after {
-                    width: 33%;
-                    right: calc(-33% + 3px);
-                    transform: scale(0.8);
-                  }
-                }
-              }
-
-              // Resets the 3rd slide:
-              + .carousel__slide--visible {
-                > div > div:first-child {
-                  transform: scale(0.8);
-                  &:after {
-                    width: 50%;
-                    right: calc(-50% - 6px);
-                    transform: scale(1);
-                  }
-                }
-              }
+          // Middle slide:
+          &.is-next {
+            ${SlideCopyWrapper} {
+              transform: scale(1.0);
             }
           }
-        }
 
+          // 2nd and 3rd:
+          // + .carousel__slide--visible {
+          //   .carousel__inner-slide {
+          //     > ${SlideCopyWrapper} {
+          //       transform: scale(1);
+          //       &:after {
+          //         width: 33%;
+          //         right: calc(-33% + 3px);
+          //         transform: scale(0.8);
+          //       }
+          //     }
+          //   }
+          // }
+
+          // Resets the 3rd slide:
+          //  + .carousel__slide--visible {
+          //      > ${SlideCopyWrapper} {
+          //        transform: scale(0.8);
+          //        &:after {
+          //          width: 50%;
+          //          right: calc(-50% - 6px);
+          //          transform: scale(1);
+          //        }
+          //      }
+          //    }
+          //  }
+
+        } // End of M breakpoint
+
+
+        
         // 'Desktop'
         @media ${({ theme }) => theme.allBreakpoints('L')} {
-          padding-bottom: ${props => props.$desktopHeight}px !important;
+          padding-bottom: ${props => props.$desktopHeight}px;
 
           // First
           &.carousel__slide--visible {
@@ -247,7 +248,7 @@ const CarouselWrapper = styled.div`
           justify-content: flex-start;
           flex-direction: column;
 
-          .slide-copy-wrapper {
+          ${SlideCopyWrapper} {
             font-size: 0.9rem;
             line-height: 0.9rem;
 

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.style.js
@@ -18,6 +18,13 @@ const SlideCopyWrapper = styled.div`
   position: relative;
   overflow: visible;
   word-wrap: break-word;
+  font-size: 0.9rem;
+  line-height: 0.9rem;
+
+  * {
+    font-size: inherit;
+    line-height: inherit;
+  }
 
   &:after {
     position: absolute;
@@ -41,6 +48,14 @@ const SlideCopyWrapper = styled.div`
 
 const HeadingCopyWrapper = styled.div`
   text-align: center;
+
+  * {
+    margin-top: 0;
+  }
+
+  h1, h2, h3 {
+    margin-bottom: 1.5rem;
+  }
 `;
 
 // Unfortunately having to target plugin-created markup ye olde fashioned way:
@@ -52,16 +67,6 @@ const CarouselWrapper = styled.div`
   margin: 0 auto;
   border-radius: 20px;
   ${defaultBoxShadow()}
-
-  ${HeadingCopyWrapper} {
-    * {
-      margin-top: 0;
-    }
-
-    h1, h2, h3 {
-      margin-bottom: 1.5rem;
-    }
-  }
 
   .splide {
     position: relative;
@@ -97,7 +102,7 @@ const CarouselWrapper = styled.div`
         position: absolute;
         top: 0;
         left: 0;
-        width: 50%;
+        width: 100%;
         height: 100%;
         transition: opacity 0.2s linear;
         background: ${({ theme, $carouselBackgroundColour }) => css`
@@ -133,15 +138,17 @@ const CarouselWrapper = styled.div`
 
     // Carousel:
     &.richtext-carousel {
+
       // All sides:
-      .splide__slide  {
+      .splide__slide {
         text-align: center;
         display: inline-flex;
         align-items: center;
         justify-content: flex-start;
         flex-direction: column;
-        padding-bottom: ${props => props.$mobileHeight}px;
+        height: ${props => props.$mobileHeight}px;
 
+        // No dashed 'connecting' line on the final slide
         &.last-slide {
           ${SlideCopyWrapper} {
             &:after {
@@ -152,7 +159,7 @@ const CarouselWrapper = styled.div`
         
         // 'Tablet' (and up) tweaks for the 3-visible layout
         @media ${({ theme }) => theme.allBreakpoints('M')} {
-          padding-bottom: ${props => props.$tabletHeight}px;
+          height: ${props => props.$tabletHeight}px;
 
            // All 'SlideCopyWrapper's:
           ${SlideCopyWrapper} {
@@ -170,6 +177,7 @@ const CarouselWrapper = styled.div`
             }
           }
 
+          // Our middle, active slide:
           &.is-active {
             ${SlideCopyWrapper} {
               transform: scale(1.0);
@@ -177,9 +185,8 @@ const CarouselWrapper = styled.div`
           }
         }
 
-        // 'Desktop'
         @media ${({ theme }) => theme.allBreakpoints('L')} {
-          padding-bottom: ${props => props.$desktopHeight}px;
+          height: ${props => props.$desktopHeight}px;
         }
       }
     }

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
@@ -198,7 +198,7 @@ it('renders custom padding + background colour version correctly', () => {
 
 .c1 {
   height: 100%;
-  background: #FFFFFF;
+  background: #F4F3F5;
   max-width: 760px;
   padding: 2.5rem 2rem 3.5rem;
   margin: 0 auto;
@@ -244,7 +244,7 @@ it('renders custom padding + background colour version correctly', () => {
   width: 100%;
   height: 100%;
   transition: opacity 0.2s linear;
-  background: linear-gradient(90deg,#FFFFFF,#FFFFFF7a,#FFFFFF00);
+  background: linear-gradient(90deg,#F4F3F5,#F4F3F57a,#F4F3F500);
 }
 
 .c1 .splide button.splide__arrow.splide__arrow--next {
@@ -255,7 +255,7 @@ it('renders custom padding + background colour version correctly', () => {
 .c1 .splide button.splide__arrow.splide__arrow--next:after {
   left: auto;
   right: 0;
-  background: linear-gradient(90deg,#FFFFFF00,#FFFFFF7a,#FFFFFF);
+  background: linear-gradient(90deg,#F4F3F500,#F4F3F57a,#F4F3F5);
 }
 
 .c1 .splide button.splide__arrow:hover:after {
@@ -276,6 +276,10 @@ it('renders custom padding + background colour version correctly', () => {
 }
 
 .c1 .splide.richtext-carousel .splide__slide.last-slide .c3:after {
+  content: none!important;
+}
+
+.c5 .splide.richtext-carousel .splide__slide.last-slide .c3:after {
   content: none!important;
 }
 
@@ -310,8 +314,8 @@ it('renders custom padding + background colour version correctly', () => {
 
   .c1 .splide.richtext-carousel .splide__slide .c3:after {
     transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
-    width: 33%;
-    right: calc(-33% - 1px);
+    width: 50%;
+    right: calc(-50% - 1px);
     transform: scale(1);
   }
 
@@ -323,6 +327,25 @@ it('renders custom padding + background colour version correctly', () => {
 @media (min-width: 1024px) {
   .c1 .splide.richtext-carousel .splide__slide {
     height: 350px;
+  }
+}
+
+@media (min-width: 740px) {
+  .c5 .splide.richtext-carousel .splide__slide .c3 {
+    transition: transform 0.75s ease;
+    transform-origin: center;
+    transform: scale(0.8);
+  }
+
+  .c5 .splide.richtext-carousel .splide__slide .c3:after {
+    transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
+    width: 50%;
+    right: calc(-50% - 1px);
+    transform: scale(1);
+  }
+
+  .c5 .splide.richtext-carousel .splide__slide.is-active .c3 {
+    transform: scale(1.0);
   }
 }
 

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
@@ -14,8 +14,18 @@ it('renders default padding version correctly', () => {
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
-.c3 {
+.c2 {
   text-align: center;
+}
+
+.c2 * {
+  margin-top: 0;
+}
+
+.c2 h1,
+.c2 h2,
+.c2 h3 {
+  margin-bottom: 1.5rem;
 }
 
 .c1 {
@@ -26,16 +36,6 @@ it('renders default padding version correctly', () => {
   margin: 0 auto;
   border-radius: 20px;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
-}
-
-.c1 .c2 * {
-  margin-top: 0;
-}
-
-.c1 .c2 h1,
-.c1 .c2 h2,
-.c1 .c2 h3 {
-  margin-bottom: 1.5rem;
 }
 
 .c1 .splide {
@@ -73,7 +73,7 @@ it('renders default padding version correctly', () => {
   position: absolute;
   top: 0;
   left: 0;
-  width: 50%;
+  width: 100%;
   height: 100%;
   transition: opacity 0.2s linear;
   background: linear-gradient(90deg,#FFFFFF,#FFFFFF7a,#FFFFFF00);
@@ -104,7 +104,7 @@ it('renders default padding version correctly', () => {
   align-items: center;
   justify-content: flex-start;
   flex-direction: column;
-  padding-bottom: 300px;
+  height: 300px;
 }
 
 .c0 {
@@ -114,13 +114,13 @@ it('renders default padding version correctly', () => {
 
 @media (min-width: 740px) {
   .c1 .splide.richtext-carousel .splide__slide {
-    padding-bottom: 350px;
+    height: 350px;
   }
 }
 
 @media (min-width: 1024px) {
   .c1 .splide.richtext-carousel .splide__slide {
-    padding-bottom: 350px;
+    height: 350px;
   }
 }
 
@@ -132,7 +132,7 @@ it('renders default padding version correctly', () => {
     id="nqIEHjiYE8Yd2A2a5cI3O"
   >
     <div
-      className="c2 c3"
+      className="c2"
     >
       Some heading copy that will be nicely constructed in-situ
     </div>
@@ -147,7 +147,7 @@ it('renders custom padding + background colour version correctly', () => {
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
-.c5 {
+.c4 {
   background: #FFFFFF;
   height: 300px;
   width: 75%;
@@ -160,9 +160,16 @@ it('renders custom padding + background colour version correctly', () => {
   position: relative;
   overflow: visible;
   word-wrap: break-word;
+  font-size: 0.9rem;
+  line-height: 0.9rem;
 }
 
-.c5:after {
+.c4 * {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.c4:after {
   position: absolute;
   content: '';
   top: 50%;
@@ -172,8 +179,18 @@ it('renders custom padding + background colour version correctly', () => {
   border-bottom: 1px dashed #969598;
 }
 
-.c3 {
+.c2 {
   text-align: center;
+}
+
+.c2 * {
+  margin-top: 0;
+}
+
+.c2 h1,
+.c2 h2,
+.c2 h3 {
+  margin-bottom: 1.5rem;
 }
 
 .c1 {
@@ -184,16 +201,6 @@ it('renders custom padding + background colour version correctly', () => {
   margin: 0 auto;
   border-radius: 20px;
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
-}
-
-.c1 .c2 * {
-  margin-top: 0;
-}
-
-.c1 .c2 h1,
-.c1 .c2 h2,
-.c1 .c2 h3 {
-  margin-bottom: 1.5rem;
 }
 
 .c1 .splide {
@@ -231,7 +238,7 @@ it('renders custom padding + background colour version correctly', () => {
   position: absolute;
   top: 0;
   left: 0;
-  width: 50%;
+  width: 100%;
   height: 100%;
   transition: opacity 0.2s linear;
   background: linear-gradient(90deg,#FFFFFF,#FFFFFF7a,#FFFFFF00);
@@ -262,10 +269,10 @@ it('renders custom padding + background colour version correctly', () => {
   align-items: center;
   justify-content: flex-start;
   flex-direction: column;
-  padding-bottom: 300px;
+  height: 300px;
 }
 
-.c1 .splide.richtext-carousel .splide__slide.last-slide .c4:after {
+.c1 .splide.richtext-carousel .splide__slide.last-slide .c3:after {
   content: none!important;
 }
 
@@ -275,44 +282,44 @@ it('renders custom padding + background colour version correctly', () => {
 }
 
 @media (min-width: 740px) {
-  .c5 {
+  .c4 {
     height: 350px;
     width: 85%;
   }
 }
 
 @media (min-width: 1024px) {
-  .c5 {
+  .c4 {
     height: 350px;
   }
 }
 
 @media (min-width: 740px) {
   .c1 .splide.richtext-carousel .splide__slide {
-    padding-bottom: 350px;
+    height: 350px;
   }
 
-  .c1 .splide.richtext-carousel .splide__slide .c4 {
+  .c1 .splide.richtext-carousel .splide__slide .c3 {
     transition: transform 0.75s ease;
     transform-origin: center;
     transform: scale(0.8);
   }
 
-  .c1 .splide.richtext-carousel .splide__slide .c4:after {
+  .c1 .splide.richtext-carousel .splide__slide .c3:after {
     transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
     width: 33%;
     right: calc(-33% - 1px);
     transform: scale(1);
   }
 
-  .c1 .splide.richtext-carousel .splide__slide.is-active .c4 {
+  .c1 .splide.richtext-carousel .splide__slide.is-active .c3 {
     transform: scale(1.0);
   }
 }
 
 @media (min-width: 1024px) {
   .c1 .splide.richtext-carousel .splide__slide {
-    padding-bottom: 350px;
+    height: 350px;
   }
 }
 
@@ -324,7 +331,7 @@ it('renders custom padding + background colour version correctly', () => {
     id="nqIEHjiYE8Yd2A2a5cI31"
   >
     <div
-      className="c2 c3"
+      className="c2"
     >
       Some heading copy that will be nicely constructed in-situ
     </div>
@@ -343,7 +350,7 @@ it('renders custom padding + background colour version correctly', () => {
             index={0}
           >
             <div
-              className="c4 c5 slide-copy-wrapper"
+              className="c3 c4 slide-copy-wrapper"
             >
               Some other longside but not really all that long copy, who knows, it could be this long or LESS.
             </div>
@@ -354,7 +361,7 @@ it('renders custom padding + background colour version correctly', () => {
             index={1}
           >
             <div
-              className="c4 c5 slide-copy-wrapper"
+              className="c3 c4 slide-copy-wrapper"
             >
               140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets.
             </div>
@@ -365,7 +372,7 @@ it('renders custom padding + background colour version correctly', () => {
             index={2}
           >
             <div
-              className="c4 c5 slide-copy-wrapper"
+              className="c3 c4 slide-copy-wrapper"
             >
               Some other longside but not really all that long copy, who knows, it could be this long or LESS
             </div>
@@ -376,7 +383,7 @@ it('renders custom padding + background colour version correctly', () => {
             index={3}
           >
             <div
-              className="c4 c5 slide-copy-wrapper"
+              className="c3 c4 slide-copy-wrapper"
             >
               140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets. ABIGLONGLINETOFORCEONTOANEWONE
             </div>

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
@@ -14,7 +14,7 @@ it('renders default padding version correctly', () => {
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
-.c2 {
+.c3 {
   text-align: center;
 }
 
@@ -28,13 +28,13 @@ it('renders default padding version correctly', () => {
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
 }
 
-.c1 >div:first-child * {
+.c1 .c2 * {
   margin-top: 0;
 }
 
-.c1 >div:first-child h1,
-.c1 >div:first-child h2,
-.c1 >div:first-child h3 {
+.c1 .c2 h1,
+.c1 .c2 h2,
+.c1 .c2 h3 {
   margin-bottom: 1.5rem;
 }
 
@@ -65,6 +65,7 @@ it('renders default padding version correctly', () => {
   background-color: transparent;
   transform: none;
   border-radius: 0;
+  opacity: 1;
 }
 
 .c1 .splide button.splide__arrow:after {
@@ -104,14 +105,6 @@ it('renders default padding version correctly', () => {
   justify-content: flex-start;
   flex-direction: column;
   padding-bottom: 300px;
-}
-
-.c1 .splide.richtext-carousel .splide__slide .carousel__inner-slide {
-  text-align: center;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  flex-direction: column;
 }
 
 .c0 {
@@ -129,11 +122,6 @@ it('renders default padding version correctly', () => {
   .c1 .splide.richtext-carousel .splide__slide {
     padding-bottom: 350px;
   }
-
-  .c1 .splide.richtext-carousel .splide__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
-    right: calc(-125% - 5px);
-    width: 125%;
-  }
 }
 
 <div
@@ -144,7 +132,7 @@ it('renders default padding version correctly', () => {
     id="nqIEHjiYE8Yd2A2a5cI3O"
   >
     <div
-      className="c2"
+      className="c2 c3"
     >
       Some heading copy that will be nicely constructed in-situ
     </div>
@@ -159,7 +147,7 @@ it('renders custom padding + background colour version correctly', () => {
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
-.c4 {
+.c5 {
   background: #FFFFFF;
   height: 300px;
   width: 75%;
@@ -174,7 +162,7 @@ it('renders custom padding + background colour version correctly', () => {
   word-wrap: break-word;
 }
 
-.c4:after {
+.c5:after {
   position: absolute;
   content: '';
   top: 50%;
@@ -184,7 +172,7 @@ it('renders custom padding + background colour version correctly', () => {
   border-bottom: 1px dashed #969598;
 }
 
-.c2 {
+.c3 {
   text-align: center;
 }
 
@@ -198,13 +186,13 @@ it('renders custom padding + background colour version correctly', () => {
   box-shadow: rgba(0,0,0,0.15) 0px 0px 1rem;
 }
 
-.c1 >div:first-child * {
+.c1 .c2 * {
   margin-top: 0;
 }
 
-.c1 >div:first-child h1,
-.c1 >div:first-child h2,
-.c1 >div:first-child h3 {
+.c1 .c2 h1,
+.c1 .c2 h2,
+.c1 .c2 h3 {
   margin-bottom: 1.5rem;
 }
 
@@ -235,6 +223,7 @@ it('renders custom padding + background colour version correctly', () => {
   background-color: transparent;
   transform: none;
   border-radius: 0;
+  opacity: 1;
 }
 
 .c1 .splide button.splide__arrow:after {
@@ -267,10 +256,6 @@ it('renders custom padding + background colour version correctly', () => {
   display: none;
 }
 
-.c1 .splide.richtext-carousel .last-slide .c3:after {
-  content: none;
-}
-
 .c1 .splide.richtext-carousel .splide__slide {
   text-align: center;
   display: inline-flex;
@@ -280,22 +265,8 @@ it('renders custom padding + background colour version correctly', () => {
   padding-bottom: 300px;
 }
 
-.c1 .splide.richtext-carousel .splide__slide .carousel__inner-slide {
-  text-align: center;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  flex-direction: column;
-}
-
-.c1 .splide.richtext-carousel .splide__slide .carousel__inner-slide .c3 {
-  font-size: 0.9rem;
-  line-height: 0.9rem;
-}
-
-.c1 .splide.richtext-carousel .splide__slide .carousel__inner-slide .c3 * {
-  font-size: inherit;
-  line-height: inherit;
+.c1 .splide.richtext-carousel .splide__slide.last-slide .c4:after {
+  content: none!important;
 }
 
 .c0 {
@@ -304,14 +275,14 @@ it('renders custom padding + background colour version correctly', () => {
 }
 
 @media (min-width: 740px) {
-  .c4 {
+  .c5 {
     height: 350px;
     width: 85%;
   }
 }
 
 @media (min-width: 1024px) {
-  .c4 {
+  .c5 {
     height: 350px;
   }
 }
@@ -321,20 +292,20 @@ it('renders custom padding + background colour version correctly', () => {
     padding-bottom: 350px;
   }
 
-  .c1 .splide.richtext-carousel .splide__slide .c3 {
+  .c1 .splide.richtext-carousel .splide__slide .c4 {
     transition: transform 0.75s ease;
     transform-origin: center;
     transform: scale(0.8);
   }
 
-  .c1 .splide.richtext-carousel .splide__slide .c3:after {
+  .c1 .splide.richtext-carousel .splide__slide .c4:after {
     transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
-    width: 100%;
-    right: calc(-100% - 6px);
+    width: 33%;
+    right: calc(-33% - 1px);
     transform: scale(1);
   }
 
-  .c1 .splide.richtext-carousel .splide__slide.is-next .c3 {
+  .c1 .splide.richtext-carousel .splide__slide.is-active .c4 {
     transform: scale(1.0);
   }
 }
@@ -342,11 +313,6 @@ it('renders custom padding + background colour version correctly', () => {
 @media (min-width: 1024px) {
   .c1 .splide.richtext-carousel .splide__slide {
     padding-bottom: 350px;
-  }
-
-  .c1 .splide.richtext-carousel .splide__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
-    right: calc(-125% - 5px);
-    width: 125%;
   }
 }
 
@@ -358,7 +324,7 @@ it('renders custom padding + background colour version correctly', () => {
     id="nqIEHjiYE8Yd2A2a5cI31"
   >
     <div
-      className="c2"
+      className="c2 c3"
     >
       Some heading copy that will be nicely constructed in-situ
     </div>
@@ -372,53 +338,49 @@ it('renders custom padding + background colour version correctly', () => {
           className="splide__list"
         >
           <li
-            className="splide__slide bookend-first"
-            index={0}
-          />
-          <li
             className="splide__slide"
-            index={1}
+            data-index={0}
+            index={0}
           >
             <div
-              className="c3 c4 slide-copy-wrapper"
+              className="c4 c5 slide-copy-wrapper"
             >
               Some other longside but not really all that long copy, who knows, it could be this long or LESS.
             </div>
           </li>
           <li
             className="splide__slide"
-            index={2}
+            data-index={1}
+            index={1}
           >
             <div
-              className="c3 c4 slide-copy-wrapper"
+              className="c4 c5 slide-copy-wrapper"
             >
               140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets.
             </div>
           </li>
           <li
             className="splide__slide"
-            index={3}
+            data-index={2}
+            index={2}
           >
             <div
-              className="c3 c4 slide-copy-wrapper"
+              className="c4 c5 slide-copy-wrapper"
             >
               Some other longside but not really all that long copy, who knows, it could be this long or LESS
             </div>
           </li>
           <li
             className="splide__slide last-slide"
-            index={4}
+            data-index={3}
+            index={3}
           >
             <div
-              className="c3 c4 slide-copy-wrapper"
+              className="c4 c5 slide-copy-wrapper"
             >
               140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets. ABIGLONGLINETOFORCEONTOANEWONE
             </div>
           </li>
-          <li
-            className="splide__slide"
-            index={5}
-          />
         </ul>
       </div>
     </div>

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
@@ -126,13 +126,16 @@ it('renders default padding version correctly', () => {
 
 <div
   className="c0"
+  data-testid="richtext-carousel--container"
 >
   <div
     className="c1 CarouselWrapper"
+    data-testid="richtext-carousel--wrapper"
     id="nqIEHjiYE8Yd2A2a5cI3O"
   >
     <div
       className="c2"
+      data-testid="richtext-carousel--heading"
     >
       Some heading copy that will be nicely constructed in-situ
     </div>
@@ -325,18 +328,22 @@ it('renders custom padding + background colour version correctly', () => {
 
 <div
   className="c0"
+  data-testid="richtext-carousel--container"
 >
   <div
     className="c1 CarouselWrapper"
+    data-testid="richtext-carousel--wrapper"
     id="nqIEHjiYE8Yd2A2a5cI31"
   >
     <div
       className="c2"
+      data-testid="richtext-carousel--heading"
     >
       Some heading copy that will be nicely constructed in-situ
     </div>
     <div
       className="splide richtext-carousel"
+      data-testid="richtext-carousel--splide"
     >
       <div
         className="splide__track"
@@ -347,10 +354,12 @@ it('renders custom padding + background colour version correctly', () => {
           <li
             className="splide__slide"
             data-index={0}
+            data-testid="richtext-carousel--slide"
             index={0}
           >
             <div
               className="c3 c4 slide-copy-wrapper"
+              data-testid="richtext-carousel--copy"
             >
               Some other longside but not really all that long copy, who knows, it could be this long or LESS.
             </div>
@@ -358,10 +367,12 @@ it('renders custom padding + background colour version correctly', () => {
           <li
             className="splide__slide"
             data-index={1}
+            data-testid="richtext-carousel--slide"
             index={1}
           >
             <div
               className="c3 c4 slide-copy-wrapper"
+              data-testid="richtext-carousel--copy"
             >
               140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets.
             </div>
@@ -369,10 +380,12 @@ it('renders custom padding + background colour version correctly', () => {
           <li
             className="splide__slide"
             data-index={2}
+            data-testid="richtext-carousel--slide"
             index={2}
           >
             <div
               className="c3 c4 slide-copy-wrapper"
+              data-testid="richtext-carousel--copy"
             >
               Some other longside but not really all that long copy, who knows, it could be this long or LESS
             </div>
@@ -380,10 +393,12 @@ it('renders custom padding + background colour version correctly', () => {
           <li
             className="splide__slide last-slide"
             data-index={3}
+            data-testid="richtext-carousel--slide"
             index={3}
           >
             <div
               className="c3 c4 slide-copy-wrapper"
+              data-testid="richtext-carousel--copy"
             >
               140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets. ABIGLONGLINETOFORCEONTOANEWONE
             </div>

--- a/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarousel.test.js
@@ -38,28 +38,36 @@ it('renders default padding version correctly', () => {
   margin-bottom: 1.5rem;
 }
 
-.c1 .carousel {
+.c1 .splide {
   position: relative;
   margin: 0 auto;
   padding-top: 2rem;
 }
 
-.c1 .carousel button.carousel__back-button,
-.c1 .carousel button.carousel__next-button {
+.c1 .splide .splide__arrows {
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+
+.c1 .splide button.splide__arrow {
   position: absolute;
   left: 0;
   top: 0;
-  width: 33%!important;
+  width: 33.3%;
   height: 100%;
-  padding: 0!important;
+  padding: 0;
   box-shadow: none;
   text-indent: -9999px;
   background-color: transparent;
-  border: none;
+  transform: none;
+  border-radius: 0;
 }
 
-.c1 .carousel button.carousel__back-button:after,
-.c1 .carousel button.carousel__next-button:after {
+.c1 .splide button.splide__arrow:after {
   content: "";
   position: absolute;
   top: 0;
@@ -70,58 +78,40 @@ it('renders default padding version correctly', () => {
   background: linear-gradient(90deg,#FFFFFF,#FFFFFF7a,#FFFFFF00);
 }
 
-.c1 .carousel button.carousel__back-button:hover:after,
-.c1 .carousel button.carousel__next-button:hover:after {
-  opacity: 0.5;
-}
-
-.c1 .carousel button.carousel__next-button {
+.c1 .splide button.splide__arrow.splide__arrow--next {
   left: auto;
   right: 0;
 }
 
-.c1 .carousel button.carousel__next-button:before {
-  transform: translate(0,-50%) rotate(-90deg);
-}
-
-.c1 .carousel button.carousel__next-button:after {
+.c1 .splide button.splide__arrow.splide__arrow--next:after {
   left: auto;
   right: 0;
   background: linear-gradient(90deg,#FFFFFF00,#FFFFFF7a,#FFFFFF);
 }
 
-.c1 .carousel .richtext-carousel {
-  transition: -webkit-transform 0.75s;
-  -o-transition: transform 0.75s;
-  transition: transform 0.75s;
-  -webkit-transform: 0.75s;
-  will-change: transform;
+.c1 .splide button.splide__arrow:hover:after {
+  opacity: 0.5;
 }
 
-.c1 .carousel .richtext-carousel .last-slide .slide-copy-wrapper:after {
-  content: none;
+.c1 .splide button.splide__arrow svg {
+  display: none;
 }
 
-.c1 .carousel .richtext-carousel .carousel__slide {
-  padding-bottom: 300px!important;
-}
-
-.c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide {
+.c1 .splide.richtext-carousel .splide__slide {
   text-align: center;
   display: inline-flex;
   align-items: center;
   justify-content: flex-start;
   flex-direction: column;
+  padding-bottom: 300px;
 }
 
-.c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide .slide-copy-wrapper {
-  font-size: 0.9rem;
-  line-height: 0.9rem;
-}
-
-.c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide .slide-copy-wrapper * {
-  font-size: inherit;
-  line-height: inherit;
+.c1 .splide.richtext-carousel .splide__slide .carousel__inner-slide {
+  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-direction: column;
 }
 
 .c0 {
@@ -130,68 +120,17 @@ it('renders default padding version correctly', () => {
 }
 
 @media (min-width: 740px) {
-  .c1 .carousel button.carousel__back-button,
-  .c1 .carousel button.carousel__next-button {
-    width: 33.3%!important;
-  }
-
-  .c1 .carousel button.carousel__back-button:after,
-  .c1 .carousel button.carousel__next-button:after {
-    width: 100%;
-  }
-}
-
-@media (min-width: 740px) {
-  .c1 .carousel .richtext-carousel .carousel__slide {
-    padding-bottom: 350px!important;
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide >div:first-child {
-    transition: transform 0.75s ease;
-    transform-origin: center;
-    transform: scale(0.8);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide >div:first-child:after {
-    transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
-    width: 100%;
-    right: calc(-100% - 6px);
-    transform: scale(1);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
-    width: 33%;
-    right: calc(-33% - 3px);
-    transform: scale(1);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child {
-    transform: scale(1);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
-    width: 33%;
-    right: calc(-33% + 3px);
-    transform: scale(0.8);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible >div>div:first-child {
-    transform: scale(0.8);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible >div>div:first-child:after {
-    width: 50%;
-    right: calc(-50% - 6px);
-    transform: scale(1);
+  .c1 .splide.richtext-carousel .splide__slide {
+    padding-bottom: 350px;
   }
 }
 
 @media (min-width: 1024px) {
-  .c1 .carousel .richtext-carousel .carousel__slide {
-    padding-bottom: 350px!important;
+  .c1 .splide.richtext-carousel .splide__slide {
+    padding-bottom: 350px;
   }
 
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
+  .c1 .splide.richtext-carousel .splide__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
     right: calc(-125% - 5px);
     width: 125%;
   }
@@ -220,7 +159,7 @@ it('renders custom padding + background colour version correctly', () => {
   ).toJSON();
 
   expect(tree).toMatchInlineSnapshot(`
-.c3 {
+.c4 {
   background: #FFFFFF;
   height: 300px;
   width: 75%;
@@ -235,7 +174,7 @@ it('renders custom padding + background colour version correctly', () => {
   word-wrap: break-word;
 }
 
-.c3:after {
+.c4:after {
   position: absolute;
   content: '';
   top: 50%;
@@ -269,28 +208,36 @@ it('renders custom padding + background colour version correctly', () => {
   margin-bottom: 1.5rem;
 }
 
-.c1 .carousel {
+.c1 .splide {
   position: relative;
   margin: 0 auto;
   padding-top: 2rem;
 }
 
-.c1 .carousel button.carousel__back-button,
-.c1 .carousel button.carousel__next-button {
+.c1 .splide .splide__arrows {
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+}
+
+.c1 .splide button.splide__arrow {
   position: absolute;
   left: 0;
   top: 0;
-  width: 33%!important;
+  width: 33.3%;
   height: 100%;
-  padding: 0!important;
+  padding: 0;
   box-shadow: none;
   text-indent: -9999px;
   background-color: transparent;
-  border: none;
+  transform: none;
+  border-radius: 0;
 }
 
-.c1 .carousel button.carousel__back-button:after,
-.c1 .carousel button.carousel__next-button:after {
+.c1 .splide button.splide__arrow:after {
   content: "";
   position: absolute;
   top: 0;
@@ -301,43 +248,39 @@ it('renders custom padding + background colour version correctly', () => {
   background: linear-gradient(90deg,#FFFFFF,#FFFFFF7a,#FFFFFF00);
 }
 
-.c1 .carousel button.carousel__back-button:hover:after,
-.c1 .carousel button.carousel__next-button:hover:after {
-  opacity: 0.5;
-}
-
-.c1 .carousel button.carousel__next-button {
+.c1 .splide button.splide__arrow.splide__arrow--next {
   left: auto;
   right: 0;
 }
 
-.c1 .carousel button.carousel__next-button:before {
-  transform: translate(0,-50%) rotate(-90deg);
-}
-
-.c1 .carousel button.carousel__next-button:after {
+.c1 .splide button.splide__arrow.splide__arrow--next:after {
   left: auto;
   right: 0;
   background: linear-gradient(90deg,#FFFFFF00,#FFFFFF7a,#FFFFFF);
 }
 
-.c1 .carousel .richtext-carousel {
-  transition: -webkit-transform 0.75s;
-  -o-transition: transform 0.75s;
-  transition: transform 0.75s;
-  -webkit-transform: 0.75s;
-  will-change: transform;
+.c1 .splide button.splide__arrow:hover:after {
+  opacity: 0.5;
 }
 
-.c1 .carousel .richtext-carousel .last-slide .slide-copy-wrapper:after {
+.c1 .splide button.splide__arrow svg {
+  display: none;
+}
+
+.c1 .splide.richtext-carousel .last-slide .c3:after {
   content: none;
 }
 
-.c1 .carousel .richtext-carousel .carousel__slide {
-  padding-bottom: 300px!important;
+.c1 .splide.richtext-carousel .splide__slide {
+  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-direction: column;
+  padding-bottom: 300px;
 }
 
-.c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide {
+.c1 .splide.richtext-carousel .splide__slide .carousel__inner-slide {
   text-align: center;
   display: inline-flex;
   align-items: center;
@@ -345,12 +288,12 @@ it('renders custom padding + background colour version correctly', () => {
   flex-direction: column;
 }
 
-.c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide .slide-copy-wrapper {
+.c1 .splide.richtext-carousel .splide__slide .carousel__inner-slide .c3 {
   font-size: 0.9rem;
   line-height: 0.9rem;
 }
 
-.c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide .slide-copy-wrapper * {
+.c1 .splide.richtext-carousel .splide__slide .carousel__inner-slide .c3 * {
   font-size: inherit;
   line-height: inherit;
 }
@@ -361,81 +304,47 @@ it('renders custom padding + background colour version correctly', () => {
 }
 
 @media (min-width: 740px) {
-  .c3 {
+  .c4 {
     height: 350px;
     width: 85%;
   }
 }
 
 @media (min-width: 1024px) {
-  .c3 {
+  .c4 {
     height: 350px;
   }
 }
 
 @media (min-width: 740px) {
-  .c1 .carousel button.carousel__back-button,
-  .c1 .carousel button.carousel__next-button {
-    width: 33.3%!important;
+  .c1 .splide.richtext-carousel .splide__slide {
+    padding-bottom: 350px;
   }
 
-  .c1 .carousel button.carousel__back-button:after,
-  .c1 .carousel button.carousel__next-button:after {
-    width: 100%;
-  }
-}
-
-@media (min-width: 740px) {
-  .c1 .carousel .richtext-carousel .carousel__slide {
-    padding-bottom: 350px!important;
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide >div:first-child {
+  .c1 .splide.richtext-carousel .splide__slide .c3 {
     transition: transform 0.75s ease;
     transform-origin: center;
     transform: scale(0.8);
   }
 
-  .c1 .carousel .richtext-carousel .carousel__slide .carousel__inner-slide >div:first-child:after {
+  .c1 .splide.richtext-carousel .splide__slide .c3:after {
     transition: transform 0.75s ease,width 0.75s ease,right 0.75s ease;
     width: 100%;
     right: calc(-100% - 6px);
     transform: scale(1);
   }
 
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
-    width: 33%;
-    right: calc(-33% - 3px);
-    transform: scale(1);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child {
-    transform: scale(1);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
-    width: 33%;
-    right: calc(-33% + 3px);
-    transform: scale(0.8);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible >div>div:first-child {
-    transform: scale(0.8);
-  }
-
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible >div>div:first-child:after {
-    width: 50%;
-    right: calc(-50% - 6px);
-    transform: scale(1);
+  .c1 .splide.richtext-carousel .splide__slide.is-next .c3 {
+    transform: scale(1.0);
   }
 }
 
 @media (min-width: 1024px) {
-  .c1 .carousel .richtext-carousel .carousel__slide {
-    padding-bottom: 350px!important;
+  .c1 .splide.richtext-carousel .splide__slide {
+    padding-bottom: 350px;
   }
 
-  .c1 .carousel .richtext-carousel .carousel__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
+  .c1 .splide.richtext-carousel .splide__slide.carousel__slide--visible +.carousel__slide--visible +.carousel__slide--visible .carousel__inner-slide >div:first-child:after {
     right: calc(-125% - 5px);
     width: 125%;
   }
@@ -454,195 +363,64 @@ it('renders custom padding + background colour version correctly', () => {
       Some heading copy that will be nicely constructed in-situ
     </div>
     <div
-      className="carousel"
+      className="splide richtext-carousel"
     >
       <div
-        aria-label="slider"
-        aria-live="polite"
-        className="horizontalSlider___281Ls carousel__slider carousel__slider--horizontal"
-        onKeyDown={[Function]}
-        role="listbox"
-        style={{}}
+        className="splide__track"
       >
-        <div
-          className="carousel__slider-tray-wrapper carousel__slider-tray-wrap--horizontal"
-          style={{}}
+        <ul
+          className="splide__list"
         >
-          <div
-            className="sliderTray___-vHFQ richtext-carousel carousel__slider-tray carousel__slider-tray--horizontal"
-            onClickCapture={[Function]}
-            onMouseDown={[Function]}
-            onTouchCancel={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            style={
-              {
-                "flexDirection": "row",
-                "transform": "translateX(0%) translateX(0px)",
-                "width": "200%",
-              }
-            }
+          <li
+            className="splide__slide bookend-first"
+            index={0}
+          />
+          <li
+            className="splide__slide"
+            index={1}
           >
             <div
-              aria-label="slide"
-              aria-selected={true}
-              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--visible"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              role="option"
-              style={
-                {
-                  "paddingBottom": "66.66666666666667%",
-                  "width": "16.666666666666668%",
-                }
-              }
+              className="c3 c4 slide-copy-wrapper"
             >
-              <div
-                className="slideInner___2mfX9 carousel__inner-slide"
-                style={{}}
-              />
+              Some other longside but not really all that long copy, who knows, it could be this long or LESS.
             </div>
+          </li>
+          <li
+            className="splide__slide"
+            index={2}
+          >
             <div
-              aria-label="slide"
-              aria-selected={true}
-              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--visible"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              role="option"
-              style={
-                {
-                  "paddingBottom": "66.66666666666667%",
-                  "width": "16.666666666666668%",
-                }
-              }
+              className="c3 c4 slide-copy-wrapper"
             >
-              <div
-                className="slideInner___2mfX9 carousel__inner-slide"
-                style={{}}
-              >
-                <div
-                  className="c3 slide-copy-wrapper"
-                >
-                  Some other longside but not really all that long copy, who knows, it could be this long or LESS.
-                </div>
-              </div>
+              140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets.
             </div>
+          </li>
+          <li
+            className="splide__slide"
+            index={3}
+          >
             <div
-              aria-label="slide"
-              aria-selected={true}
-              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--visible"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              role="option"
-              style={
-                {
-                  "paddingBottom": "66.66666666666667%",
-                  "width": "16.666666666666668%",
-                }
-              }
+              className="c3 c4 slide-copy-wrapper"
             >
-              <div
-                className="slideInner___2mfX9 carousel__inner-slide"
-                style={{}}
-              >
-                <div
-                  className="c3 slide-copy-wrapper"
-                >
-                  140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets.
-                </div>
-              </div>
+              Some other longside but not really all that long copy, who knows, it could be this long or LESS
             </div>
+          </li>
+          <li
+            className="splide__slide last-slide"
+            index={4}
+          >
             <div
-              aria-label="slide"
-              aria-selected={false}
-              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              role="option"
-              style={
-                {
-                  "paddingBottom": "66.66666666666667%",
-                  "width": "16.666666666666668%",
-                }
-              }
+              className="c3 c4 slide-copy-wrapper"
             >
-              <div
-                className="slideInner___2mfX9 carousel__inner-slide"
-                style={{}}
-              >
-                <div
-                  className="c3 slide-copy-wrapper"
-                >
-                  Some other longside but not really all that long copy, who knows, it could be this long or LESS
-                </div>
-              </div>
+              140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets. ABIGLONGLINETOFORCEONTOANEWONE
             </div>
-            <div
-              aria-label="slide"
-              aria-selected={false}
-              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden last-slide"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              role="option"
-              style={
-                {
-                  "paddingBottom": "66.66666666666667%",
-                  "width": "16.666666666666668%",
-                }
-              }
-            >
-              <div
-                className="slideInner___2mfX9 carousel__inner-slide"
-                style={{}}
-              >
-                <div
-                  className="c3 slide-copy-wrapper"
-                >
-                  140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets. ABIGLONGLINETOFORCEONTOANEWONE
-                </div>
-              </div>
-            </div>
-            <div
-              aria-label="slide"
-              aria-selected={false}
-              className="slide___3-Nqo slideHorizontal___1NzNV carousel__slide carousel__slide--hidden"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              role="option"
-              style={
-                {
-                  "paddingBottom": "66.66666666666667%",
-                  "width": "16.666666666666668%",
-                }
-              }
-            >
-              <div
-                className="slideInner___2mfX9 carousel__inner-slide"
-                style={{}}
-              />
-            </div>
-          </div>
-        </div>
+          </li>
+          <li
+            className="splide__slide"
+            index={5}
+          />
+        </ul>
       </div>
-      <button
-        aria-label="previous"
-        className="buttonBack___1mlaL carousel__back-button"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-      >
-        Back
-      </button>
-      <button
-        aria-label="next"
-        className="buttonNext___2mOCa carousel__next-button"
-        disabled={false}
-        onClick={[Function]}
-        type="button"
-      >
-        Next
-      </button>
     </div>
   </div>
 </div>

--- a/src/components/Organisms/RichtextCarousel/RichtextCarouselExample.jsx
+++ b/src/components/Organisms/RichtextCarousel/RichtextCarouselExample.jsx
@@ -7,12 +7,12 @@ export default function RichtextCarouselExample() {
   return (
     <>
       <ExampleContainer>
-        <h2 style={{ textAlign: 'center' }}>Richtext Carousel #1 (default padding)</h2>
+        <h2 style={{ textAlign: 'center' }}>Richtext Carousel #1 (default padding, autoplay off)</h2>
         <RichtextCarousel data={RichtextCarouselItems} />
       </ExampleContainer>
 
       <ExampleContainer>
-        <h2 style={{ textAlign: 'center' }}>Richtext Carousel #2 (custom padding)</h2>
+        <h2 style={{ textAlign: 'center' }}>Richtext Carousel #2 (custom padding, autoplay on)</h2>
         <RichtextCarousel data={RichtextCarouselItemsWithPadding} />
       </ExampleContainer>
     </>

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.js
@@ -39,6 +39,7 @@ const WYMDCarousel = ({ data }) => {
       $paddingTop={paddingTop}
       $paddingBottom={paddingBottom}
       $backgroundColour={backgroundColour}
+      data-testid="wymd-carousel--container"
     >
 
       <CarouselWrapper
@@ -47,22 +48,37 @@ const WYMDCarousel = ({ data }) => {
         $mobileHeight={mobileHeight}
         $tabletHeight={tabletHeight}
         $desktopHeight={desktopHeight}
+        data-testid="wymd-carousel--wrapper"
       >
-        <Heading tag="p" weight="bold">
+        <Heading
+          tag="p"
+          weight="bold"
+          data-testid="wymd-carousel--heading"
+        >
           { headerCopy}
         </Heading>
 
-        <PeopleHelpedText tag="h1" family="Anton" weight="normal" color="red">
+        <PeopleHelpedText
+          tag="h1"
+          family="Anton"
+          weight="normal"
+          color="red"
+          data-testid="wymd-carousel--people-helped"
+        >
           { peopleHelpedText}
         </PeopleHelpedText>
 
-        <Including tag="p">
+        <Including
+          tag="p"
+          data-testid="wymd-carousel--including"
+        >
           including...
         </Including>
 
         {theseItems && (
         <Splide
           className="wymd-carousel"
+          data-testid="wymd-carousel--splide"
           options={{
             speed: 750,
             rewindSpeed: 750,
@@ -97,6 +113,7 @@ const WYMDCarousel = ({ data }) => {
                 key={safeIndex}
                 index={safeIndex}
                 data-index={safeIndex}
+                data-testid="wymd-carousel--slide"
               >
                 <SlideInner>
                   <ImageWrapper className="image-wrapper">
@@ -105,13 +122,20 @@ const WYMDCarousel = ({ data }) => {
 
                   <AllTextWrapper>
                     <AmountWrapper>
-                      <Text tag="h1" family="Anton">
+                      <Text
+                        tag="h1"
+                        family="Anton"
+                        data-testid="wymd-carousel--amount"
+                      >
                         {theseItems[key].amount}
                       </Text>
                     </AmountWrapper>
 
                     <CopyWrapper>
-                      <Text tag="p">
+                      <Text
+                        tag="p"
+                        data-testid="wymd-carousel--copy"
+                      >
                         {theseItems[key].copy}
                       </Text>
                     </CopyWrapper>

--- a/src/components/Organisms/WYMDCarousel/WYMDCarousel.style.js
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarousel.style.js
@@ -211,19 +211,6 @@ const CarouselWrapper = styled.div`
       }
     }
 
-    // Reorientate for the right-side 'next' button
-    button.carousel__next-button {
-      left: auto;
-      right: 0;
-
-      &:after {
-        left: auto;
-        right: 0;
-        background: linear-gradient(270deg, rgba(255, 255, 255, 1),
-        rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0));
-      }
-    }
-
     // Carousel:
     &.wymd-carousel {
       .splide__slide {

--- a/src/components/Organisms/WYMDCarousel/WYMDCarouselExample.jsx
+++ b/src/components/Organisms/WYMDCarousel/WYMDCarouselExample.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import WYMDCarousel from './WYMDCarousel';
 import {
-  carouselItemsComplete, carouselItemsCompleteWithPadding, carouselItemsIncomplete, carouselItemsMinimal
+  carouselItemsComplete, carouselItemsCompleteWithPadding,
+  carouselItemsIncomplete, carouselItemsMinimal
 } from '../../../data/data';
 import { ExampleContainer } from '../../../demos/SharedStyles';
 

--- a/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
+++ b/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
@@ -695,28 +695,34 @@ exports[`renders the customised padding version correctly:
 
 <div
   className="c0"
+  data-testid="wymd-carousel--container"
 >
   <div
     className="c1 CarouselWrapper"
+    data-testid="wymd-carousel--wrapper"
     id="7zdR84QkZwrTh9NWx2H926"
   >
     <p
       className="c2 c3"
+      data-testid="wymd-carousel--heading"
     >
       Over the past two years, we've supported
     </p>
     <h1
       className="c4 c5"
+      data-testid="wymd-carousel--people-helped"
     >
       11.7 million people
     </h1>
     <p
       className="c6 c7"
+      data-testid="wymd-carousel--including"
     >
       including...
     </p>
     <div
       className="splide wymd-carousel"
+      data-testid="wymd-carousel--splide"
     >
       <div
         className="splide__track"
@@ -727,6 +733,7 @@ exports[`renders the customised padding version correctly:
           <li
             className="splide__slide"
             data-index={0}
+            data-testid="wymd-carousel--slide"
             index={0}
           >
             <div
@@ -748,6 +755,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <h1
                     className="c11"
+                    data-testid="wymd-carousel--amount"
                   >
                     1,000
                   </h1>
@@ -757,6 +765,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <p
                     className="c6"
+                    data-testid="wymd-carousel--copy"
                   >
                     children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                   </p>
@@ -767,6 +776,7 @@ exports[`renders the customised padding version correctly:
           <li
             className="splide__slide"
             data-index={1}
+            data-testid="wymd-carousel--slide"
             index={1}
           >
             <div
@@ -788,6 +798,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <h1
                     className="c11"
+                    data-testid="wymd-carousel--amount"
                   >
                     750,000
                   </h1>
@@ -797,6 +808,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <p
                     className="c6"
+                    data-testid="wymd-carousel--copy"
                   >
                     children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                   </p>
@@ -807,6 +819,7 @@ exports[`renders the customised padding version correctly:
           <li
             className="splide__slide"
             data-index={2}
+            data-testid="wymd-carousel--slide"
             index={2}
           >
             <div
@@ -828,6 +841,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <h1
                     className="c11"
+                    data-testid="wymd-carousel--amount"
                   >
                     3,000
                   </h1>
@@ -837,6 +851,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <p
                     className="c6"
+                    data-testid="wymd-carousel--copy"
                   >
                     children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                   </p>
@@ -847,6 +862,7 @@ exports[`renders the customised padding version correctly:
           <li
             className="splide__slide"
             data-index={3}
+            data-testid="wymd-carousel--slide"
             index={3}
           >
             <div
@@ -868,6 +884,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <h1
                     className="c11"
+                    data-testid="wymd-carousel--amount"
                   >
                     4,000
                   </h1>
@@ -877,6 +894,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <p
                     className="c6"
+                    data-testid="wymd-carousel--copy"
                   >
                     children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                   </p>
@@ -887,6 +905,7 @@ exports[`renders the customised padding version correctly:
           <li
             className="splide__slide"
             data-index={4}
+            data-testid="wymd-carousel--slide"
             index={4}
           >
             <div
@@ -908,6 +927,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <h1
                     className="c11"
+                    data-testid="wymd-carousel--amount"
                   >
                     5,000
                   </h1>
@@ -917,6 +937,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <p
                     className="c6"
+                    data-testid="wymd-carousel--copy"
                   >
                     children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                   </p>
@@ -927,6 +948,7 @@ exports[`renders the customised padding version correctly:
           <li
             className="splide__slide"
             data-index={5}
+            data-testid="wymd-carousel--slide"
             index={5}
           >
             <div
@@ -948,6 +970,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <h1
                     className="c11"
+                    data-testid="wymd-carousel--amount"
                   >
                     6,000
                   </h1>
@@ -957,6 +980,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <p
                     className="c6"
+                    data-testid="wymd-carousel--copy"
                   >
                     children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                   </p>
@@ -967,6 +991,7 @@ exports[`renders the customised padding version correctly:
           <li
             className="splide__slide"
             data-index={6}
+            data-testid="wymd-carousel--slide"
             index={6}
           >
             <div
@@ -988,6 +1013,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <h1
                     className="c11"
+                    data-testid="wymd-carousel--amount"
                   >
                     7,000
                   </h1>
@@ -997,6 +1023,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <p
                     className="c6"
+                    data-testid="wymd-carousel--copy"
                   >
                     children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                   </p>
@@ -1007,6 +1034,7 @@ exports[`renders the customised padding version correctly:
           <li
             className="splide__slide"
             data-index={7}
+            data-testid="wymd-carousel--slide"
             index={7}
           >
             <div
@@ -1028,6 +1056,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <h1
                     className="c11"
+                    data-testid="wymd-carousel--amount"
                   >
                     8,000
                   </h1>
@@ -1037,6 +1066,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <p
                     className="c6"
+                    data-testid="wymd-carousel--copy"
                   >
                     children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                   </p>
@@ -1047,6 +1077,7 @@ exports[`renders the customised padding version correctly:
           <li
             className="splide__slide last-slide"
             data-index={8}
+            data-testid="wymd-carousel--slide"
             index={8}
           >
             <div
@@ -1068,6 +1099,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <h1
                     className="c11"
+                    data-testid="wymd-carousel--amount"
                   >
                     9,000
                   </h1>
@@ -1077,6 +1109,7 @@ exports[`renders the customised padding version correctly:
                 >
                   <p
                     className="c6"
+                    data-testid="wymd-carousel--copy"
                   >
                     children and young people in the UK and around the world, including with safe homes, good nutrition and access to quality healthcare and education.
                   </p>
@@ -1685,23 +1718,28 @@ exports[`renders the default padding version correctly:
 
 <div
   className="c0"
+  data-testid="wymd-carousel--container"
 >
   <div
     className="c1 CarouselWrapper"
+    data-testid="wymd-carousel--wrapper"
     id="7zdR84QkZwrTh9NWx2H926"
   >
     <p
       className="c2 c3"
+      data-testid="wymd-carousel--heading"
     >
       Over the past two years, we've supported
     </p>
     <h1
       className="c4 c5"
+      data-testid="wymd-carousel--people-helped"
     >
       11.7 million people
     </h1>
     <p
       className="c6 c7"
+      data-testid="wymd-carousel--including"
     >
       including...
     </p>

--- a/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
+++ b/src/components/Organisms/WYMDCarousel/__snapshots__/WYMDCarousel.test.js.snap
@@ -553,17 +553,6 @@ exports[`renders the customised padding version correctly:
   display: none;
 }
 
-.c1 .splide button.carousel__next-button {
-  left: auto;
-  right: 0;
-}
-
-.c1 .splide button.carousel__next-button:after {
-  left: auto;
-  right: 0;
-  background: linear-gradient(270deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
-}
-
 .c1 .splide.wymd-carousel .splide__slide {
   height: 425px;
 }
@@ -1589,17 +1578,6 @@ exports[`renders the default padding version correctly:
 
 .c1 .splide button.splide__arrow svg {
   display: none;
-}
-
-.c1 .splide button.carousel__next-button {
-  left: auto;
-  right: 0;
-}
-
-.c1 .splide button.carousel__next-button:after {
-  left: auto;
-  right: 0;
-  background: linear-gradient(270deg,rgba(255,255,255,1),rgba(255,255,255,0.5),rgba(255,255,255,0));
 }
 
 .c1 .splide.wymd-carousel .splide__slide {

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -338,7 +338,8 @@ const RichtextCarouselItemsWithPadding = {
   autoPlay: true,
   paddingBottom: '4rem',
   paddingTop: '4rem',
-  rowBackgroundColour: 'teal_light'
+  rowBackgroundColour: 'teal_light',
+  carouselBackgroundColour: 'grey_light'
 };
 
 export {

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -323,7 +323,7 @@ const RichtextCarouselItems = {
     { copy: 'Some other longside but not really all that long copy, who knows, it could be this long or LESS' },
     { copy: '140 character count limit imposed in messages to fix the design height of each container and restrict anomalies. This is based on Twitters character limit for tweets. ABIGLONGLINETOFORCEONTOANEWONE' }
   ],
-  autoPlay: true
+  autoPlay: false
 };
 
 const RichtextCarouselItemsWithPadding = {


### PR DESCRIPTION
### PR description
#### What is it doing?
Unborks `RichtextCarousel` in line with `WYMDCarousel`, entering our brave new `Splide`-based world, making it React 19-compatible and letting us gut a lot of breakpoint-y and layout-y hacks in order to make things work per the design.

#### Why is this required?
Compatibility fixes, exposing lack of tests for this component within CRcom, which will be fixed in the subsequent integration PR - (have also added data attributes for both to make tests a bit less ugly and verbose)

#### link to Jira ticket:
https://comicrelief.atlassian.net/browse/ENG-5245


### Quick Checklist:
- [x] My PR title follows the Conventional Commit spec.

- [x] I have filled out the PR description as per the template above.

- [x] I have added tests to cover new or changed behaviour.

- [x] I have updated any relevant documentation.

### Important! - lastly, make sure to squash merge...
